### PR TITLE
Bot JSON for Tests

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		3A058A8E1B31595A0077FD47 /* BotParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A058A8D1B31595A0077FD47 /* BotParsingTests.swift */; };
 		3A058A901B31596A0077FD47 /* bot_mac_xcode6.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A058A8F1B31596A0077FD47 /* bot_mac_xcode6.json */; };
 		3A058A931B315BB50077FD47 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A058A921B315BB50077FD47 /* TestUtils.swift */; };
+		3A236F6C1B335E170042A9B1 /* bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A236F671B335E170042A9B1 /* bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json */; };
+		3A236F6D1B335E170042A9B1 /* bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A236F681B335E170042A9B1 /* bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json */; };
+		3A236F6E1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_daily941_clean_always.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A236F691B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_daily941_clean_always.json */; };
+		3A236F6F1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A236F6A1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json */; };
+		3A236F701B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_weeklytuesday941.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A236F6B1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_weeklytuesday941.json */; };
 		3A7B48C01B2A5AC40077ABEA /* XcodeServerSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7B48BF1B2A5AC40077ABEA /* XcodeServerSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A7B48C61B2A5AC40077ABEA /* XcodeServerSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A7B48BA1B2A5AC40077ABEA /* XcodeServerSDK.framework */; };
 		3A7B48CD1B2A5AC40077ABEA /* XcodeServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48CC1B2A5AC40077ABEA /* XcodeServerTests.swift */; };
@@ -29,6 +34,8 @@
 		3A7B48F11B2A5B7B0077ABEA /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48F01B2A5B7B0077ABEA /* JSON.swift */; };
 		3A7B48F51B2A5BC60077ABEA /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48F41B2A5BC60077ABEA /* Logging.swift */; };
 		3A7B48F71B2A5BDA0077ABEA /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48F61B2A5BDA0077ABEA /* Errors.swift */; };
+		3AC786761B33626000BBA482 /* bot_ios_xcode7.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AC786741B33626000BBA482 /* bot_ios_xcode7.json */; };
+		3AC786771B33626000BBA482 /* bot_mac_xcode7.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AC786751B33626000BBA482 /* bot_mac_xcode7.json */; };
 		707D08961B2C684C003900F3 /* XcodeServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D08951B2C684C003900F3 /* XcodeServerConfig.swift */; };
 		707D08981B2C6954003900F3 /* EmailConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D08971B2C6954003900F3 /* EmailConfiguration.swift */; };
 		707D089A1B2C6986003900F3 /* BotSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D08991B2C6986003900F3 /* BotSchedule.swift */; };
@@ -50,6 +57,11 @@
 		3A058A8D1B31595A0077FD47 /* BotParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BotParsingTests.swift; sourceTree = "<group>"; };
 		3A058A8F1B31596A0077FD47 /* bot_mac_xcode6.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6.json; path = Data/bot_mac_xcode6.json; sourceTree = "<group>"; };
 		3A058A921B315BB50077FD47 /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
+		3A236F671B335E170042A9B1 /* bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json; path = Data/bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json; sourceTree = "<group>"; };
+		3A236F681B335E170042A9B1 /* bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json; path = Data/bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json; sourceTree = "<group>"; };
+		3A236F691B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_daily941_clean_always.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6_schedule_periodical_daily941_clean_always.json; path = Data/bot_mac_xcode6_schedule_periodical_daily941_clean_always.json; sourceTree = "<group>"; };
+		3A236F6A1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json; path = Data/bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json; sourceTree = "<group>"; };
+		3A236F6B1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_weeklytuesday941.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode6_schedule_periodical_weeklytuesday941.json; path = Data/bot_mac_xcode6_schedule_periodical_weeklytuesday941.json; sourceTree = "<group>"; };
 		3A7B48BA1B2A5AC40077ABEA /* XcodeServerSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XcodeServerSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A7B48BE1B2A5AC40077ABEA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A7B48BF1B2A5AC40077ABEA /* XcodeServerSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XcodeServerSDK.h; sourceTree = "<group>"; };
@@ -72,6 +84,8 @@
 		3A7B48F01B2A5B7B0077ABEA /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		3A7B48F41B2A5BC60077ABEA /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3A7B48F61B2A5BDA0077ABEA /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		3AC786741B33626000BBA482 /* bot_ios_xcode7.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_ios_xcode7.json; path = Data/bot_ios_xcode7.json; sourceTree = "<group>"; };
+		3AC786751B33626000BBA482 /* bot_mac_xcode7.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bot_mac_xcode7.json; path = Data/bot_mac_xcode7.json; sourceTree = "<group>"; };
 		707D08951B2C684C003900F3 /* XcodeServerConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerConfig.swift; sourceTree = "<group>"; };
 		707D08971B2C6954003900F3 /* EmailConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailConfiguration.swift; sourceTree = "<group>"; };
 		707D08991B2C6986003900F3 /* BotSchedule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BotSchedule.swift; sourceTree = "<group>"; };
@@ -102,6 +116,13 @@
 		3A058A911B31596E0077FD47 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				3AC786741B33626000BBA482 /* bot_ios_xcode7.json */,
+				3AC786751B33626000BBA482 /* bot_mac_xcode7.json */,
+				3A236F671B335E170042A9B1 /* bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json */,
+				3A236F681B335E170042A9B1 /* bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json */,
+				3A236F691B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_daily941_clean_always.json */,
+				3A236F6A1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json */,
+				3A236F6B1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_weeklytuesday941.json */,
 				3A058A8F1B31596A0077FD47 /* bot_mac_xcode6.json */,
 			);
 			name = Data;
@@ -314,7 +335,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A236F6C1B335E170042A9B1 /* bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json in Resources */,
+				3AC786771B33626000BBA482 /* bot_mac_xcode7.json in Resources */,
+				3AC786761B33626000BBA482 /* bot_ios_xcode7.json in Resources */,
 				3A058A901B31596A0077FD47 /* bot_mac_xcode6.json in Resources */,
+				3A236F6F1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json in Resources */,
+				3A236F701B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_weeklytuesday941.json in Resources */,
+				3A236F6D1B335E170042A9B1 /* bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json in Resources */,
+				3A236F6E1B335E170042A9B1 /* bot_mac_xcode6_schedule_periodical_daily941_clean_always.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XcodeServerSDKTests/Data/bot_ios_xcode7.json
+++ b/XcodeServerSDKTests/Data/bot_ios_xcode7.json
@@ -1,0 +1,87 @@
+{
+  "_id": "ef18f96409a205451df8a5b9c4031ad5",
+  "_rev": "4-820c802765bb118721d8ca48e925e977",
+  "group": {
+    "name": "F05D9D16-FAE3-4066-9909-08FAE0C69018"
+  },
+  "configuration": {
+    "builtFromClean": 0,
+    "periodicScheduleInterval": 1,
+    "codeCoveragePreference": 2,
+    "performsTestAction": true,
+    "triggers": [],
+    "performsAnalyzeAction": true,
+    "schemeName": "HelloApp",
+    "exportsProductFromArchive": true,
+    "testingDeviceIDs": [],
+    "deviceSpecification": {
+      "filters": [
+        {
+          "platform": {
+            "_id": "a85553a5b26a7c1a4998f3b237000da9",
+            "displayName": "iOS",
+            "_rev": "6-6628873592bccc61307b32bd7ea8dd83",
+            "simulatorIdentifier": "com.apple.platform.iphonesimulator",
+            "identifier": "com.apple.platform.iphoneos",
+            "buildNumber": "13A4254u",
+            "version": "9.0"
+          },
+          "filterType": 3,
+          "architectureType": 0
+        }
+      ],
+      "deviceIdentifiers": [
+        "a85553a5b26a7c1a4998f3b237001c0e",
+        "a85553a5b26a7c1a4998f3b2370033f2",
+        "a85553a5b26a7c1a4998f3b237004afd"
+      ]
+    },
+    "weeklyScheduleDay": 0,
+    "minutesAfterHourToIntegrate": 0,
+    "scheduleType": 1,
+    "hourOfIntegration": 0,
+    "performsArchiveAction": true,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "33B8ADDFBC86145BD26937EED8BB5679306D7042": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "33B8ADDFBC86145BD26937EED8BB5679306D7042",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "33B8ADDFBC86145BD26937EED8BB5679306D7042": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "33B8ADDFBC86145BD26937EED8BB5679306D7042": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "3275CCE1-A749-432A-83B5-CA57220827A0",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "33B8ADDFBC86145BD26937EED8BB5679306D7042": "HelloApp-iOS/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "HelloApp",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "HelloApp.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/HelloApp-iOS.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryTrustedCertFingerprintKey": "1627ACA576282D36631B564DEBDFA648",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "33B8ADDFBC86145BD26937EED8BB5679306D7042",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryTrustSelfSignedCertKey": true
+        }
+      ]
+    },
+    "testingDestinationType": 0
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 2,
+  "doc_type": "bot",
+  "tinyID": "C4A26D6"
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_manual_no_actions_clean_never_all_triggers.json
@@ -1,0 +1,159 @@
+{
+  "_id": "faaeae44305ec0eaf94134b66792ef54",
+  "_rev": "14-54ab137678d945f41ce62e5acf5666e4",
+  "group": {
+    "name": "8BB5C9C6-B762-4EAC-A4F6-837FA3DE45A0"
+  },
+  "configuration": {
+    "builtFromClean": 0,
+    "periodicScheduleInterval": 0,
+    "performsTestAction": false,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "cd Buildasaur\npod install",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Notify Committers on Failure",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "committer@hello.world",
+            "yo@mo.com"
+          ],
+          "emailCommitters": true,
+          "includeIssueDetails": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "Sample Script After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": false,
+    "schemeName": "Buildasaur",
+    "weeklyScheduleDay": 0,
+    "testingDeviceIDs": [],
+    "minutesAfterHourToIntegrate": 0,
+    "hourOfIntegration": 0,
+    "scheduleType": 3,
+    "performsArchiveAction": false,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "buildasaur",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0,
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "48B2E98C-DA87-4B8A-8C5D-CB6FE328F7D2",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+        },
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 6,
+  "doc_type": "bot",
+  "tinyID": "45FC428",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+        "DVTSourceControlBranchIdentifierKey": "master",
+        "DVTSourceControlLocationRevisionKey": "fe26453fe3776a76292b14e0b74d118d5ef7f0c5",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      },
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "buildasaur",
+        "DVTSourceControlLocationRevisionKey": "0278e79fe9a901e1a76e0996ef39511168417de7",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "20F0A876-ADD9-4B51-918D-5B46EA5E6007",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/",
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+      },
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_oncommit_all_actions_clean_onceaweek.json
@@ -1,0 +1,159 @@
+{
+  "_id": "faaeae44305ec0eaf94134b66792ef54",
+  "_rev": "15-799b7148f50625a7089c3cfc6b52e60d",
+  "group": {
+    "name": "8BB5C9C6-B762-4EAC-A4F6-837FA3DE45A0"
+  },
+  "configuration": {
+    "builtFromClean": 3,
+    "periodicScheduleInterval": 0,
+    "performsTestAction": true,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "cd Buildasaur\npod install",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Notify Committers on Failure",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "committer@hello.world",
+            "yo@mo.com"
+          ],
+          "emailCommitters": true,
+          "includeIssueDetails": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "Sample Script After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": true,
+    "schemeName": "Buildasaur",
+    "weeklyScheduleDay": 0,
+    "testingDeviceIDs": [],
+    "minutesAfterHourToIntegrate": 0,
+    "hourOfIntegration": 0,
+    "scheduleType": 2,
+    "performsArchiveAction": true,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "buildasaur",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0,
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "48B2E98C-DA87-4B8A-8C5D-CB6FE328F7D2",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+        },
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 6,
+  "doc_type": "bot",
+  "tinyID": "45FC428",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "buildasaur",
+        "DVTSourceControlLocationRevisionKey": "0278e79fe9a901e1a76e0996ef39511168417de7",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      },
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+        "DVTSourceControlBranchIdentifierKey": "master",
+        "DVTSourceControlLocationRevisionKey": "fe26453fe3776a76292b14e0b74d118d5ef7f0c5",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "20F0A876-ADD9-4B51-918D-5B46EA5E6007",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+      },
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_daily941_clean_always.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_daily941_clean_always.json
@@ -1,0 +1,159 @@
+{
+  "_id": "faaeae44305ec0eaf94134b66792ef54",
+  "_rev": "17-392a76642a574caabff866b70b22d934",
+  "group": {
+    "name": "8BB5C9C6-B762-4EAC-A4F6-837FA3DE45A0"
+  },
+  "configuration": {
+    "builtFromClean": 1,
+    "periodicScheduleInterval": 2,
+    "performsTestAction": true,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "cd Buildasaur\npod install",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Notify Committers on Failure",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "committer@hello.world",
+            "yo@mo.com"
+          ],
+          "emailCommitters": true,
+          "includeIssueDetails": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "Sample Script After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": true,
+    "schemeName": "Buildasaur",
+    "weeklyScheduleDay": 0,
+    "testingDeviceIDs": [],
+    "minutesAfterHourToIntegrate": 41,
+    "hourOfIntegration": 9,
+    "scheduleType": 1,
+    "performsArchiveAction": true,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "buildasaur",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0,
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "48B2E98C-DA87-4B8A-8C5D-CB6FE328F7D2",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+        },
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 6,
+  "doc_type": "bot",
+  "tinyID": "45FC428",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "buildasaur",
+        "DVTSourceControlLocationRevisionKey": "0278e79fe9a901e1a76e0996ef39511168417de7",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      },
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+        "DVTSourceControlBranchIdentifierKey": "master",
+        "DVTSourceControlLocationRevisionKey": "fe26453fe3776a76292b14e0b74d118d5ef7f0c5",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "20F0A876-ADD9-4B51-918D-5B46EA5E6007",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+      },
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_onhour15minsafter_clean_onceaday.json
@@ -1,0 +1,159 @@
+{
+  "_id": "faaeae44305ec0eaf94134b66792ef54",
+  "_rev": "16-5f7764e3d09ccb3a5679a151d42865c0",
+  "group": {
+    "name": "8BB5C9C6-B762-4EAC-A4F6-837FA3DE45A0"
+  },
+  "configuration": {
+    "builtFromClean": 2,
+    "periodicScheduleInterval": 1,
+    "performsTestAction": true,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "cd Buildasaur\npod install",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Notify Committers on Failure",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "committer@hello.world",
+            "yo@mo.com"
+          ],
+          "emailCommitters": true,
+          "includeIssueDetails": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "Sample Script After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": true,
+    "schemeName": "Buildasaur",
+    "weeklyScheduleDay": 0,
+    "testingDeviceIDs": [],
+    "minutesAfterHourToIntegrate": 15,
+    "hourOfIntegration": 0,
+    "scheduleType": 1,
+    "performsArchiveAction": true,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "buildasaur",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0,
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "48B2E98C-DA87-4B8A-8C5D-CB6FE328F7D2",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+        },
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 6,
+  "doc_type": "bot",
+  "tinyID": "45FC428",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+        "DVTSourceControlBranchIdentifierKey": "master",
+        "DVTSourceControlLocationRevisionKey": "fe26453fe3776a76292b14e0b74d118d5ef7f0c5",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      },
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "buildasaur",
+        "DVTSourceControlLocationRevisionKey": "0278e79fe9a901e1a76e0996ef39511168417de7",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "20F0A876-ADD9-4B51-918D-5B46EA5E6007",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/",
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+      },
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_weeklytuesday941.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode6_schedule_periodical_weeklytuesday941.json
@@ -1,0 +1,159 @@
+{
+  "_id": "faaeae44305ec0eaf94134b66792ef54",
+  "_rev": "18-f5e91dd5c1a6b5cab16741ba0e6ca19f",
+  "group": {
+    "name": "8BB5C9C6-B762-4EAC-A4F6-837FA3DE45A0"
+  },
+  "configuration": {
+    "builtFromClean": 1,
+    "periodicScheduleInterval": 3,
+    "performsTestAction": true,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "cd Buildasaur\npod install",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Notify Committers on Failure",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "committer@hello.world",
+            "yo@mo.com"
+          ],
+          "emailCommitters": true,
+          "includeIssueDetails": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "Sample Script After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": false,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": true,
+    "schemeName": "Buildasaur",
+    "weeklyScheduleDay": 2,
+    "testingDeviceIDs": [],
+    "minutesAfterHourToIntegrate": 41,
+    "hourOfIntegration": 9,
+    "scheduleType": 1,
+    "performsArchiveAction": true,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "buildasaur",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlBranchIdentifierKey": "master",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        },
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0,
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "48B2E98C-DA87-4B8A-8C5D-CB6FE328F7D2",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/",
+        "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+        },
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 6,
+  "doc_type": "bot",
+  "tinyID": "45FC428",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": {
+        "DVTSourceControlBranchIdentifierKey": "master",
+        "DVTSourceControlLocationRevisionKey": "fe26453fe3776a76292b14e0b74d118d5ef7f0c5",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      },
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "buildasaur",
+        "DVTSourceControlLocationRevisionKey": "0278e79fe9a901e1a76e0996ef39511168417de7",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "20F0A876-ADD9-4B51-918D-5B46EA5E6007",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "1C5C2A17EEADA6DBF6678501245487A71FBE28BB": "Buildasaur/",
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "Buildasaur-XcodeServerSDK/"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "Buildasaur",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "Buildasaur.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/Buildasaur.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
+      },
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}

--- a/XcodeServerSDKTests/Data/bot_mac_xcode7.json
+++ b/XcodeServerSDKTests/Data/bot_mac_xcode7.json
@@ -1,0 +1,156 @@
+{
+  "_id": "ef18f96409a205451df8a5b9c402d36f",
+  "_rev": "5-ba18e0a7b78aea3dfc125fe541340df7",
+  "group": {
+    "name": "F28A6883-FBF6-41AA-BF65-58E916906E96"
+  },
+  "configuration": {
+    "builtFromClean": 0,
+    "periodicScheduleInterval": 1,
+    "codeCoveragePreference": 2,
+    "performsTestAction": true,
+    "triggers": [
+      {
+        "phase": 1,
+        "scriptBody": "Before",
+        "type": 1,
+        "name": "Run Script"
+      },
+      {
+        "phase": 2,
+        "scriptBody": "After",
+        "type": 1,
+        "name": "Run Script",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": true,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        }
+      },
+      {
+        "phase": 2,
+        "scriptBody": "",
+        "type": 2,
+        "name": "Send Email Notification",
+        "conditions": {
+          "status": 2,
+          "onWarnings": true,
+          "onBuildErrors": true,
+          "onInternalErrors": true,
+          "onAnalyzerWarnings": true,
+          "onFailingTests": true,
+          "onSuccess": true
+        },
+        "emailConfiguration": {
+          "includeCommitMessages": true,
+          "additionalRecipients": [
+            "email@me.com",
+            "hello@world.com"
+          ],
+          "emailCommitters": true,
+          "scmOptions": {
+            "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": true
+          },
+          "includeIssueDetails": true
+        }
+      }
+    ],
+    "performsAnalyzeAction": true,
+    "schemeName": "XcodeServerSDK",
+    "exportsProductFromArchive": true,
+    "testingDeviceIDs": [],
+    "deviceSpecification": {
+      "filters": [
+        {
+          "platform": {
+            "buildNumber": "15A178w",
+            "_id": "a85553a5b26a7c1a4998f3b237000b18",
+            "_rev": "6-ec2620829704318e5207916618d5101b",
+            "displayName": "OS X",
+            "identifier": "com.apple.platform.macosx",
+            "version": "1.1"
+          },
+          "filterType": 0,
+          "architectureType": 1
+        }
+      ],
+      "deviceIdentifiers": []
+    },
+    "weeklyScheduleDay": 0,
+    "minutesAfterHourToIntegrate": 0,
+    "scheduleType": 1,
+    "hourOfIntegration": 0,
+    "performsArchiveAction": true,
+    "testingDestinationType": 7,
+    "sourceControlBlueprint": {
+      "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlBranchIdentifierKey": "swift-2",
+          "DVTSourceControlBranchOptionsKey": 214,
+          "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey": {},
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationStrategiesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryAuthenticationTypeKey": "DVTSourceControlSSHKeysAuthenticationStrategy"
+        }
+      },
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": 0
+      },
+      "DVTSourceControlWorkspaceBlueprintIdentifierKey": "68B5DED7-3FEF-4D55-A6F7-973537EC51FD",
+      "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+        "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "XcodeServerSDK/"
+      },
+      "DVTSourceControlWorkspaceBlueprintNameKey": "XcodeServerSDK",
+      "DVTSourceControlWorkspaceBlueprintVersion": 203,
+      "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "XcodeServerSDK.xcworkspace",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+        {
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryTrustedCertFingerprintKey": "1627ACA576282D36631B564DEBDFA648",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97",
+          "DVTSourceControlWorkspaceBlueprintRemoteRepositoryTrustSelfSignedCertKey": true
+        }
+      ]
+    }
+  },
+  "requiresUpgrade": false,
+  "name": "TESTBOT",
+  "type": 1,
+  "integration_counter": 2,
+  "doc_type": "bot",
+  "tinyID": "A851ED5",
+  "lastRevisionBlueprint": {
+    "DVTSourceControlWorkspaceBlueprintLocationsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": {
+        "DVTSourceControlBranchIdentifierKey": "swift-2",
+        "DVTSourceControlLocationRevisionKey": "991da08565c38ea9ea7e6bd7db1acce49e4ae701",
+        "DVTSourceControlBranchOptionsKey": 50,
+        "DVTSourceControlWorkspaceBlueprintLocationTypeKey": "DVTSourceControlBranch"
+      }
+    },
+    "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97",
+    "DVTSourceControlWorkspaceBlueprintIdentifierKey": "CD185E3B-5B34-4E15-9CFA-9DFB1D715DB5",
+    "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey": {
+      "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97": "XcodeServerSDK"
+    },
+    "DVTSourceControlWorkspaceBlueprintNameKey": "XcodeServerSDK",
+    "DVTSourceControlWorkspaceBlueprintVersion": 203,
+    "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey": "XcodeServerSDK.xcworkspace",
+    "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey": [
+      {
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey": "github.com:czechboy0/XcodeServerSDK.git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey": "com.apple.dt.Xcode.sourcecontrol.Git",
+        "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey": "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
added more example json payloads for bot parsing tests. my worry is that supporting both Xcode 6 and 7 reliably will be too much work going forwards.

@cojoj, this should answer your question in #16. I tried naming the json files by the significant values inside. 
