### PR TITLE
Add XcodeServerConfig test coverage

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		707D089A1B2C6986003900F3 /* BotSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D08991B2C6986003900F3 /* BotSchedule.swift */; };
 		707D089C1B2C69C4003900F3 /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D089B1B2C69C4003900F3 /* Trigger.swift */; };
 		707D089E1B2C6A1F003900F3 /* TriggerConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D089D1B2C6A1F003900F3 /* TriggerConditions.swift */; };
+		709ED67C1B35FD3F00A06038 /* XcodeServerEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */; };
+		709ED6801B3608FC00A06038 /* XcodeServerConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +93,8 @@
 		707D08991B2C6986003900F3 /* BotSchedule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BotSchedule.swift; sourceTree = "<group>"; };
 		707D089B1B2C69C4003900F3 /* Trigger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trigger.swift; sourceTree = "<group>"; };
 		707D089D1B2C6A1F003900F3 /* TriggerConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerConditions.swift; sourceTree = "<group>"; };
+		709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerEntityTests.swift; sourceTree = "<group>"; };
+		709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerConfigTests.swift; sourceTree = "<group>"; };
 		70F463361B2B3F4600C3F963 /* Interactions.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Interactions.playground; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -177,6 +181,8 @@
 			children = (
 				3A058A911B31596E0077FD47 /* Data */,
 				3A7B48CC1B2A5AC40077ABEA /* XcodeServerTests.swift */,
+				709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */,
+				709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */,
 				3A058A8D1B31595A0077FD47 /* BotParsingTests.swift */,
 				3A058A921B315BB50077FD47 /* TestUtils.swift */,
 				3A7B48CA1B2A5AC40077ABEA /* Supporting Files */,
@@ -382,8 +388,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A058A8E1B31595A0077FD47 /* BotParsingTests.swift in Sources */,
+				709ED67C1B35FD3F00A06038 /* XcodeServerEntityTests.swift in Sources */,
 				3A058A931B315BB50077FD47 /* TestUtils.swift in Sources */,
 				3A7B48CD1B2A5AC40077ABEA /* XcodeServerTests.swift in Sources */,
+				709ED6801B3608FC00A06038 /* XcodeServerConfigTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -39,7 +39,7 @@ public class XcodeServerConfig : JSONSerializable {
         if let url = NSURL(string: host) {
             if url.scheme.isEmpty {
                 // exted host with https scheme
-                host.extend("https://")
+                host = "https://" + host
             } else if url.scheme != "https" {
                 Log.error("Xcode Server generally uses https, please double check your hostname")
             }

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -1,0 +1,60 @@
+//
+//  XcodeServerConfigTests.swift
+//  XcodeServerSDK
+//
+//  Created by Mateusz Zając on 20/06/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+import XcodeServerSDK
+
+class XcodeServerConfigTests: XCTestCase {
+
+    // MARK: Initialization testing
+    func testManualInit() {
+        let config = XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
+        
+        XCTAssertEqual(config.host, "https://127.0.0.1", "Should create proper host address")
+        XCTAssertEqual(config.user!, "ICanCreateBots")
+        XCTAssertEqual(config.password!, "superSecr3t")
+    }
+    
+    func testDictionaryInit() {
+        let json = [
+            "host": "https://127.0.0.1",
+            "user": "ICanCreateBots",
+            "password": "superSecr3t"
+        ]
+        
+        let config = XcodeServerConfig(json: json)
+        
+        XCTAssertEqual(config!.host, "https://127.0.0.1", "Should create proper host address")
+        XCTAssertEqual(config!.user!, "ICanCreateBots")
+        XCTAssertEqual(config!.password!, "superSecr3t")
+    }
+    
+    func testNilDictionaryInit() {
+        let json = [
+            "user": "ICanCreateBots",
+            "password": "superSecr3t"
+        ]
+        
+        let config = XcodeServerConfig(json: json)
+        
+        XCTAssertNil(config)
+    }
+    
+    // MARK: Returning JSON
+    func testJsonify() {
+        let config = XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
+        let expected = [
+            "host": "https://127.0.0.1",
+            "user": "ICanCreateBots",
+            "password": "superSecr3t"
+        ]
+        
+        XCTAssertEqual(config.jsonify(), expected)
+    }
+
+}

--- a/XcodeServerSDKTests/XcodeServerEntityTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEntityTests.swift
@@ -1,0 +1,30 @@
+//
+//  XcodeServerEntityTests.swift
+//  XcodeServerSDK
+//
+//  Created by Mateusz Zając on 20/06/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+import XcodeServerSDK
+
+class XcodeServerEntityTests: XCTestCase {
+    
+    // MARK: No arguments init
+    func testInit() {
+        let defaultEntity = XcodeServerEntity()
+        
+        XCTAssertNil(defaultEntity.id, "ID should be nil")
+        XCTAssertNil(defaultEntity.rev, "Rev should be nil")
+        XCTAssertNil(defaultEntity.tinyID, "Tiny ID should be nil")
+    }
+    
+    func testDictionarify() {
+        // let defaultEntity = XcodeServerEntity()
+        
+        // Unable to test assertions in Swift...
+        // XCTAssertNotNil(defaultEntity.dictionarify(), "Should return empty NSDictionary")
+    }
+    
+}


### PR DESCRIPTION
I've created test cases for `XcodeServerConfig` but I think this class need some refactoring as there are some edge cases. I'll provide an **issue** for this where I'll explain the possible causes of failure and fixes.
