### PR TITLE
Refactored `XcodeServerConfig`

### DIFF
--- a/XcodeServerSDK/Utils/JSON.swift
+++ b/XcodeServerSDK/Utils/JSON.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol JSONSerializable {
-    init?(json: NSDictionary)
+    init?(json: NSDictionary) throws
     func jsonify() -> NSDictionary
 }
 

--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -42,21 +42,21 @@ public class XcodeServerConfig : JSONSerializable {
         return dict
     }
     
-    ///
-    /// Initializes a server configuration with the provided host.
-    /// - parameter host: `Xcode` server host.
-    /// - paramater user: Username that will be used to authenticate against the `host` provided.
-    /// Can be `nil`.
-    ///
-    /// - parameter password: Password that will be used to authenticate against the `host` provided.
-    /// Can be `nil`.
-    ///
-    /// - returns: A fully initialized `XcodeServerConfig` instance.
-    ///
-    /// - throws:
-    ///     - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
-    ///     - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
-    ///
+    /**
+    Initializes a server configuration with the provided host.
+    - parameter host: `Xcode` server host.
+    - paramater user: Username that will be used to authenticate against the `host` provided.
+    Can be `nil`.
+    
+    - parameter password: Password that will be used to authenticate against the `host` provided.
+    Can be `nil`.
+    
+    - returns: A fully initialized `XcodeServerConfig` instance.
+    
+    - throws:
+        - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
+        - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
+    */
     public required init(var host: String, user: String?, password: String?) throws {
         guard let url = NSURL(string: host) else {
             /*******************************************************************
@@ -95,17 +95,17 @@ public class XcodeServerConfig : JSONSerializable {
         self.availabilityState = .Unchecked
     }
     
-    ///
-    /// Initializes a server configuration with the provided `json`.
-    /// - parameter json: `NSDictionary` containing the `XcodeServerConfig` «configuration».
-    ///
-    /// - returns: A fully initialized `XcodeServerConfig` instance.
-    ///
-    /// - throws:
-    ///     - `NoHostProvided`: When no `host` key was found on the provided `json` dictionary.
-    ///     - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
-    ///     - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
-    ///
+    /**
+    Initializes a server configuration with the provided `json`.
+    - parameter json: `NSDictionary` containing the `XcodeServerConfig` «configuration».
+    
+    - returns: A fully initialized `XcodeServerConfig` instance.
+    
+    - throws:
+        - `NoHostProvided`: When no `host` key was found on the provided `json` dictionary.
+        - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
+        - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
+    */
     public required convenience init?(json: NSDictionary) throws {
         guard let host = json.optionalStringForKey("host") else {
             throw ConfigurationErrors.NoHostProvided

--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -42,6 +42,21 @@ public class XcodeServerConfig : JSONSerializable {
         return dict
     }
     
+    ///
+    /// Initializes a server configuration with the provided host.
+    /// - parameter host: `Xcode` server host.
+    /// - paramater user: Username that will be used to authenticate against the `host` provided.
+    /// Can be `nil`.
+    ///
+    /// - parameter password: Password that will be used to authenticate against the `host` provided.
+    /// Can be `nil`.
+    ///
+    /// - returns: A fully initialized `XcodeServerConfig` instance.
+    ///
+    /// - throws:
+    ///     - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
+    ///     - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
+    ///
     public required init(var host: String, user: String?, password: String?) throws {
         guard let url = NSURL(string: host) else {
             /*******************************************************************
@@ -80,6 +95,17 @@ public class XcodeServerConfig : JSONSerializable {
         self.availabilityState = .Unchecked
     }
     
+    ///
+    /// Initializes a server configuration with the provided `json`.
+    /// - parameter json: `NSDictionary` containing the `XcodeServerConfig` «configuration».
+    ///
+    /// - returns: A fully initialized `XcodeServerConfig` instance.
+    ///
+    /// - throws:
+    ///     - `NoHostProvided`: When no `host` key was found on the provided `json` dictionary.
+    ///     - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
+    ///     - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
+    ///
     public required convenience init?(json: NSDictionary) throws {
         guard let host = json.optionalStringForKey("host") else {
             throw ConfigurationErrors.NoHostProvided

--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -15,9 +15,13 @@ public enum AvailabilityCheckState {
     case Succeeded
 }
 
+/// Posible errors thrown by `XcodeServerConfig`
 public enum ConfigurationErrors : ErrorType {
+    /// Thrown when no host was provided
     case NoHostProvided
+    /// Thrown when an invalid host is provided (host is returned)
     case InvalidHostProvided(String)
+    /// Thrown when a host is provided with an invalid scheme (explanation message returned)
     case InvalidSchemeProvided(String)
 }
 
@@ -28,7 +32,7 @@ public class XcodeServerConfig : JSONSerializable {
     public let password: String?
     public let port: Int = 20343
     
-    public var availabilityState: AvailabilityCheckState
+    public var availabilityState: AvailabilityCheckState = .Unchecked
     
     public func jsonify() -> NSDictionary {
         let dict = NSMutableDictionary()
@@ -40,12 +44,26 @@ public class XcodeServerConfig : JSONSerializable {
     
     public required init(var host: String, user: String?, password: String?) throws {
         guard let url = NSURL(string: host) else {
+            /*******************************************************************
+             **   Had to be added to silence the compiler ¯\_(ツ)_/¯
+             **   Radar: http://openradar.me/21514477
+             **   Reply: https://twitter.com/jckarter/status/613491369311535104
+             ******************************************************************/
+            self.host = ""; self.user = nil; self.password = nil
+            
             throw ConfigurationErrors.InvalidHostProvided(host)
         }
         
         guard url.scheme.isEmpty || url.scheme == "https" else {
             let errMsg = "Xcode Server generally uses https, please double check your hostname"
             Log.error(errMsg)
+            
+            /*******************************************************************
+            **   Had to be added to silence the compiler ¯\_(ツ)_/¯
+            **   Radar: http://openradar.me/21514477
+            **   Reply: https://twitter.com/jckarter/status/613491369311535104
+            ******************************************************************/
+            self.host = ""; self.user = nil; self.password = nil
             
             throw ConfigurationErrors.InvalidSchemeProvided(errMsg)
         }

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -50,6 +50,8 @@ class XcodeServerConfigTests: XCTestCase {
         
         do {
             _ = try XcodeServerConfig(json: json)
+            
+            XCTFail("`XcodeServerConfig` init did not throw `ConfigurationErrors.NoHostProvided` when an invalid dictionary was passed.")
         } catch ConfigurationErrors.NoHostProvided {
             print("• `ConfigurationErrors.NoHostProvided` was thrown as expected.")
         } catch {

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -13,11 +13,15 @@ class XcodeServerConfigTests: XCTestCase {
 
     // MARK: Initialization testing
     func testManualInit() {
-        let config = XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
-        
-        XCTAssertEqual(config.host, "https://127.0.0.1", "Should create proper host address")
-        XCTAssertEqual(config.user!, "ICanCreateBots")
-        XCTAssertEqual(config.password!, "superSecr3t")
+        do {
+            let config = try XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
+            
+            XCTAssertEqual(config.host, "https://127.0.0.1", "Should create proper host address")
+            XCTAssertEqual(config.user!, "ICanCreateBots")
+            XCTAssertEqual(config.password!, "superSecr3t")
+        } catch {
+            XCTFail("Failed to initialize the server configuration: \(error)")
+        }
     }
     
     func testDictionaryInit() {
@@ -27,34 +31,46 @@ class XcodeServerConfigTests: XCTestCase {
             "password": "superSecr3t"
         ]
         
-        let config = XcodeServerConfig(json: json)
-        
-        XCTAssertEqual(config!.host, "https://127.0.0.1", "Should create proper host address")
-        XCTAssertEqual(config!.user!, "ICanCreateBots")
-        XCTAssertEqual(config!.password!, "superSecr3t")
+        do {
+            let config = try XcodeServerConfig(json: json)
+            
+            XCTAssertEqual(config!.host, "https://127.0.0.1", "Should create proper host address")
+            XCTAssertEqual(config!.user!, "ICanCreateBots")
+            XCTAssertEqual(config!.password!, "superSecr3t")
+        } catch {
+            XCTFail("Failed to initialize the server configuration: \(error)")
+        }
     }
     
-    func testNilDictionaryInit() {
+    func testInvalidDictionaryInit() {
         let json = [
             "user": "ICanCreateBots",
             "password": "superSecr3t"
         ]
         
-        let config = XcodeServerConfig(json: json)
-        
-        XCTAssertNil(config)
+        do {
+            _ = try XcodeServerConfig(json: json)
+        } catch ConfigurationErrors.NoHostProvided {
+            print("• `ConfigurationErrors.NoHostProvided` was thrown as expected.")
+        } catch {
+            XCTFail("`XcodeServerConfig` init failed with an unexpected error: \(error).")
+        }
     }
     
     // MARK: Returning JSON
     func testJsonify() {
-        let config = XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
-        let expected = [
-            "host": "https://127.0.0.1",
-            "user": "ICanCreateBots",
-            "password": "superSecr3t"
-        ]
-        
-        XCTAssertEqual(config.jsonify(), expected)
+        do {
+            let config = try XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
+            let expected = [
+                "host": "https://127.0.0.1",
+                "user": "ICanCreateBots",
+                "password": "superSecr3t"
+            ]
+            
+            XCTAssertEqual(config.jsonify(), expected)
+        } catch {
+            XCTFail("Failed to initialize the server configuration: \(error)")
+        }
     }
 
 }

--- a/XcodeServerSDKTests/XcodeServerTests.swift
+++ b/XcodeServerSDKTests/XcodeServerTests.swift
@@ -16,12 +16,15 @@ class XcodeServerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        
-        let config = XcodeServerConfig(
-            host: "https://127.0.0.1",
-            user: "ICanCreateBots",
-            password: "superSecr3t")
-        self.server = XcodeServerFactory.server(config)
+        do {
+            let config = try XcodeServerConfig(
+                host: "https://127.0.0.1",
+                user: "ICanCreateBots",
+                password: "superSecr3t")
+            self.server = XcodeServerFactory.server(config)
+        } catch {
+            XCTFail("Failed to initialize the server configuration: \(error)")
+        }
     }
     
     func testServerCreation() {


### PR DESCRIPTION
# Fix #28 (?)

As suggested by @czechboy0 here's a `PR` with the new «throwable» init approach using some `guards` and a custom error enum.
## Done:
- [x] «Extended» `JSONSerializable` to `throw` on `init`
- [x] Implemented «throwable» inits on `XcodeServerConfig`
- [x] Generated custom `ErrorType`
- [x] Added _FUGLY_ code to silence complier on «throwable» init

![](http://i.imgur.com/8y5ABu4.gif)
