### PR TITLE
Test Assertions for throwing methods

### DIFF
--- a/XcodeServerSDKTests/TestUtils.swift
+++ b/XcodeServerSDKTests/TestUtils.swift
@@ -21,6 +21,8 @@ struct StringError: ErrorType {
     }
 }
 
+
+// MARK: Mock JSON helper methods
 extension XCTestCase {
     
     func loadJSONWithName(name: String) -> NSDictionary {
@@ -55,5 +57,88 @@ extension XCTestCase {
         let bot = self.botInFileWithName(name)
         let configuration = bot.configuration
         return configuration
+    }
+}
+
+// MARK: Exception assertions
+// Based on: https://forums.developer.apple.com/thread/5824
+extension XCTestCase {
+    /**
+    Replacement method for XCTAssertThrowsError which isn't currently supported.
+    
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertThrowsError(message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+            
+            let msg = (message == "") ? "Tested block did not throw error as expected." : message
+            XCTFail(msg, file: file, line: line)
+        } catch {}
+    }
+    
+    /**
+    Replacement method for XCTAssertThrowsSpecificError which isn't currently supported.
+    
+    - parameter kind:    ErrorType which is expected to be thrown from block
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertThrowsSpecificError(kind: ErrorType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+            
+            let msg = (message == "") ? "Tested block did not throw expected \(kind) error." : message
+            XCTFail(msg, file: file, line: line)
+        } catch let error as NSError {
+            let expected = kind as NSError
+            if ((error.domain != expected.domain) || (error.code != expected.code)) {
+                let msg = (message == "") ? "Tested block threw \(error), not expected \(kind) error." : message
+                XCTFail(msg, file: file, line: line)
+            }
+        }
+    }
+    
+    /**
+    Replacement method for XCTAssertNoThrowsError which isn't currently supported.
+    
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertNoThrowError(message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+        } catch {
+            let msg = (message == "") ? "Tested block threw unexpected error." : message
+            XCTFail(msg, file: file, line: line)
+        }
+    }
+    
+    /**
+    Replacement method for XCTAssertNoThrowsSpecificError which isn't currently supported.
+    
+    - parameter kind:    ErrorType which isn't expected to be thrown from block
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertNoThrowSpecificError(kind: ErrorType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+        } catch let error as NSError {
+            let unwanted = kind as NSError
+            if ((error.domain == unwanted.domain) && (error.code == unwanted.code)) {
+                let msg = (message == "") ? "Tested block threw unexpected \(kind) error." : message  
+                XCTFail(msg, file: file, line: line)  
+            }  
+        }  
     }
 }

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -48,20 +48,14 @@ class XcodeServerConfigTests: XCTestCase {
             "password": "superSecr3t"
         ]
         
-        do {
-            _ = try XcodeServerConfig(json: json)
-            
-            XCTFail("`XcodeServerConfig` init did not throw `ConfigurationErrors.NoHostProvided` when an invalid dictionary was passed.")
-        } catch ConfigurationErrors.NoHostProvided {
-            print("• `ConfigurationErrors.NoHostProvided` was thrown as expected.")
-        } catch {
-            XCTFail("`XcodeServerConfig` init failed with an unexpected error: \(error).")
+        XCTempAssertThrowsSpecificError(ConfigurationErrors.NoHostProvided) {
+            try XcodeServerConfig(json: json)
         }
     }
     
     // MARK: Returning JSON
     func testJsonify() {
-        do {
+        XCTempAssertNoThrowError("Failed to initialize the server configuration") {
             let config = try XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
             let expected = [
                 "host": "https://127.0.0.1",
@@ -70,8 +64,6 @@ class XcodeServerConfigTests: XCTestCase {
             ]
             
             XCTAssertEqual(config.jsonify(), expected)
-        } catch {
-            XCTFail("Failed to initialize the server configuration: \(error)")
         }
     }
 


### PR DESCRIPTION
As suggested by @esttorhe in #36 I've added implementation of custom **assertion** methods which are missing in the current state of Swift 😓 (Hope they'll add those soon)

I used a great [resource](https://forums.developer.apple.com/thread/5824), added header docs, formatted code and put everything into separate `extension` on `XCTestCase`.

What's more, small updates were made to test cases created by @esttorhe (probably?) to see if everything works like it should and it looks like it is! ☺️
