### PR TITLE
Move API routes to separate files

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		70B21FF81B3AFB1D00EAD4EB /* BotConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B21FF71B3AFB1D00EAD4EB /* BotConfigurationTests.swift */; };
 		70C2D8381B431BCE008845FB /* XcodeServer+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */; };
 		70C2D8391B431F1E008845FB /* RepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704591851B40945700BA226C /* RepositoryTests.swift */; };
+		70C2D8411B43273A008845FB /* XcodeServer+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */; };
+		70C2D8451B43273B008845FB /* XcodeServer+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */; };
 		70E1413A1B409EA000AC98DB /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 		70E1413B1B409EA100AC98DB /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 /* End PBXBuildFile section */
@@ -758,6 +760,7 @@
 				11376BDE1B3A2FE30005A681 /* BotConfiguration.swift in Sources */,
 				11376BDF1B3A2FE30005A681 /* EmailConfiguration.swift in Sources */,
 				11376BE61B3A2FEB0005A681 /* CIServer.swift in Sources */,
+				70C2D8451B43273B008845FB /* XcodeServer+Auth.swift in Sources */,
 				11376BE71B3A2FEB0005A681 /* Errors.swift in Sources */,
 				11376BE81B3A2FEB0005A681 /* Server.swift in Sources */,
 				11376BE91B3A2FEB0005A681 /* XcodeServerConstants.swift in Sources */,
@@ -789,6 +792,7 @@
 				11FB71B21B34AF3300D57A52 /* Server.swift in Sources */,
 				11FB71B31B34AF3300D57A52 /* XcodeServerConstants.swift in Sources */,
 				11FB71A71B34AF2400D57A52 /* Bot.swift in Sources */,
+				70C2D8411B43273A008845FB /* XcodeServer+Auth.swift in Sources */,
 				11FB71A81B34AF2400D57A52 /* BotConfiguration.swift in Sources */,
 				11FB71A91B34AF2400D57A52 /* EmailConfiguration.swift in Sources */,
 				11FB71AA1B34AF2400D57A52 /* BotSchedule.swift in Sources */,

--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		709ED67C1B35FD3F00A06038 /* XcodeServerEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */; };
 		709ED6801B3608FC00A06038 /* XcodeServerConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */; };
 		70B21FF81B3AFB1D00EAD4EB /* BotConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B21FF71B3AFB1D00EAD4EB /* BotConfigurationTests.swift */; };
+		70C2D8381B431BCE008845FB /* XcodeServer+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */; };
+		70C2D8391B431F1E008845FB /* RepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704591851B40945700BA226C /* RepositoryTests.swift */; };
 		70E1413A1B409EA000AC98DB /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 		70E1413B1B409EA100AC98DB /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 /* End PBXBuildFile section */
@@ -241,6 +243,7 @@
 		709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerEntityTests.swift; sourceTree = "<group>"; };
 		709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerConfigTests.swift; sourceTree = "<group>"; };
 		70B21FF71B3AFB1D00EAD4EB /* BotConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BotConfigurationTests.swift; sourceTree = "<group>"; };
+		70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XcodeServer+Auth.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -340,6 +343,7 @@
 			children = (
 				3A7B48BF1B2A5AC40077ABEA /* XcodeServerSDK.h */,
 				3A7B48DC1B2A5ADE0077ABEA /* XcodeServer.swift */,
+				70C2D8331B4319CB008845FB /* API Routes */,
 				3A7B48DF1B2A5ADE0077ABEA /* XcodeServerEntity.swift */,
 				707D08951B2C684C003900F3 /* XcodeServerConfig.swift */,
 				3A7B48DE1B2A5ADE0077ABEA /* XcodeServerEndpoints.swift */,
@@ -453,6 +457,14 @@
 				3A7B48DD1B2A5ADE0077ABEA /* XcodeServerConstants.swift */,
 			);
 			path = "Server Helpers";
+			sourceTree = "<group>";
+		};
+		70C2D8331B4319CB008845FB /* API Routes */ = {
+			isa = PBXGroup;
+			children = (
+				70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */,
+			);
+			path = "API Routes";
 			sourceTree = "<group>";
 		};
 		70F463351B2B3EF800C3F963 /* Playgrounds */ = {
@@ -803,7 +815,7 @@
 				11FB71B81B34B00000D57A52 /* XcodeServerTests.swift in Sources */,
 				3A06D5FF1B3C184D00F0A6C5 /* HTTPUtilsTests.swift in Sources */,
 				3A06D5FD1B3C184400F0A6C5 /* XcodeServerEntityTests.swift in Sources */,
-				704591871B40945E00BA226C /* RepositoryTests.swift in Sources */,
+				70C2D8391B431F1E008845FB /* RepositoryTests.swift in Sources */,
 				11FB71B91B34B00000D57A52 /* BotParsingTests.swift in Sources */,
 				11FB71BA1B34B00000D57A52 /* TestUtils.swift in Sources */,
 				3A06D5FE1B3C184700F0A6C5 /* XcodeServerConfigTests.swift in Sources */,
@@ -823,6 +835,7 @@
 				3A7B48E91B2A5ADE0077ABEA /* XcodeServerEndpoints.swift in Sources */,
 				3A7B48E51B2A5ADE0077ABEA /* Integration.swift in Sources */,
 				3A7B48E81B2A5ADE0077ABEA /* XcodeServerConstants.swift in Sources */,
+				70C2D8381B431BCE008845FB /* XcodeServer+Auth.swift in Sources */,
 				707D089C1B2C69C4003900F3 /* Trigger.swift in Sources */,
 				3A7B48E21B2A5ADE0077ABEA /* BotConfiguration.swift in Sources */,
 				3A7B48EA1B2A5ADE0077ABEA /* XcodeServerEntity.swift in Sources */,

--- a/XcodeServerSDK/API Routes/XcodeServer+Auth.swift
+++ b/XcodeServerSDK/API Routes/XcodeServer+Auth.swift
@@ -1,0 +1,104 @@
+//
+//  XcodeServer+Auth.swift
+//  XcodeServerSDK
+//
+//  Created by Mateusz Zając on 30.06.2015.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - XcodeSever API Routes for Authorization
+extension XcodeServer {
+    
+    // MARK: Sign in/Sign out
+    
+    /**
+    XCS API call for user sign in.
+    
+    - parameter success:    Indicates whether sign in was successful.
+    - parameter error:      Error indicating failure of sign in.
+    */
+    public final func login(completion: (success: Bool, error: NSError?) -> ()) {
+        
+        self.sendRequestWithMethod(.POST, endpoint: .Login, params: nil, query: nil, body: nil) { (response, body, error) -> () in
+            
+            if error != nil {
+                completion(success: false, error: error)
+                return
+            }
+            
+            if let response = response {
+                if response.statusCode == 204 {
+                    completion(success: true, error: nil)
+                } else {
+                    completion(success: false, error: Error.withInfo("Wrong status code: \(response.statusCode)"))
+                }
+                return
+            }
+            completion(success: false, error: Error.withInfo("Nil response"))
+        }
+    }
+    
+    /**
+    XCS API call for user sign out.
+    
+    - parameter success:    Indicates whether sign out was successful.
+    - parameter error:      Error indicating failure of sign out.
+    */
+    public final func logout(completion: (success: Bool, error: NSError?) -> ()) {
+        
+        self.sendRequestWithMethod(.POST, endpoint: .Logout, params: nil, query: nil, body: nil) { (response, body, error) -> () in
+            
+            if error != nil {
+                completion(success: false, error: error)
+                return
+            }
+            
+            if let response = response {
+                if response.statusCode == 204 {
+                    completion(success: true, error: nil)
+                } else {
+                    completion(success: false, error: Error.withInfo("Wrong status code: \(response.statusCode)"))
+                }
+                return
+            }
+            completion(success: false, error: Error.withInfo("Nil response"))
+        }
+    }
+    
+    // MARK: User access helpers
+    
+    /**
+    Checks whether the current user has the rights to create bots and perform other similar "write" actions.
+    Xcode Server offers two tiers of users, ones for reading only ("viewers") and others for management.
+    Here we check the current user can manage XCS, which is useful for projects like Buildasaur.
+    
+    - parameter success:    Indicates if user can create bots.
+    - parameter error:      Error if something went wrong.
+    */
+    public final func verifyXCSUserCanCreateBots(completion: (success: Bool, error: NSError?) -> ()) {
+        
+        //the way we check availability is first by logging out (does nothing if not logged in) and then
+        //calling getUserCanCreateBots, which, if necessary, automatically authenticates with Basic auth before resolving to true or false in JSON.
+        
+        self.logout { (success, error) -> () in
+            
+            if let error = error {
+                completion(success: false, error: error)
+                return
+            }
+            
+            self.getUserCanCreateBots { (canCreateBots, error) -> () in
+                
+                if let error = error {
+                    completion(success: false, error: error)
+                    return
+                }
+                
+                completion(success: canCreateBots, error: nil)
+            }
+        }
+    }
+    
+}

--- a/XcodeServerSDK/XcodeServer.swift
+++ b/XcodeServerSDK/XcodeServer.swift
@@ -106,7 +106,7 @@ public extension XcodeServer {
     }
     
     //API functionality
-    private func sendRequestWithMethod(method: HTTP.Method, endpoint: XcodeServerEndPoints.Endpoint, params: [String: String]?, query: [String: String]?, body: NSDictionary?, completion: HTTP.Completion) {
+    internal func sendRequestWithMethod(method: HTTP.Method, endpoint: XcodeServerEndPoints.Endpoint, params: [String: String]?, query: [String: String]?, body: NSDictionary?, completion: HTTP.Completion) {
         
         var allParams = [
             "method": method.rawValue
@@ -153,48 +153,6 @@ public extension XcodeServer {
             
         } else {
             completion(response: nil, body: nil, error: Error.withInfo("Couldn't create Request"))
-        }
-    }
-    
-    public func login(completion: (success: Bool, error: NSError?) -> ()) {
-        
-        self.sendRequestWithMethod(.POST, endpoint: .Login, params: nil, query: nil, body: nil) { (response, body, error) -> () in
-            
-            if error != nil {
-                completion(success: false, error: error)
-                return
-            }
-            
-            if let response = response {
-                if response.statusCode == 204 {
-                    completion(success: true, error: nil)
-                } else {
-                    completion(success: false, error: Error.withInfo("Wrong status code: \(response.statusCode)"))
-                }
-                return
-            }
-            completion(success: false, error: Error.withInfo("Nil response"))
-        }
-    }
-    
-    public func logout(completion: (success: Bool, error: NSError?) -> ()) {
-        
-        self.sendRequestWithMethod(.POST, endpoint: .Logout, params: nil, query: nil, body: nil) { (response, body, error) -> () in
-            
-            if error != nil {
-                completion(success: false, error: error)
-                return
-            }
-            
-            if let response = response {
-                if response.statusCode == 204 {
-                    completion(success: true, error: nil)
-                } else {
-                    completion(success: false, error: Error.withInfo("Wrong status code: \(response.statusCode)"))
-                }
-                return
-            }
-            completion(success: false, error: Error.withInfo("Nil response"))
         }
     }
     
@@ -613,35 +571,6 @@ public extension XcodeServer {
     }
     
     //more advanced
-    
-    /**
-    Checks whether the current user has the rights to create bots and perform other similar "write" actions.
-    Xcode Server offers two tiers of users, ones for reading only ("viewers") and others for management.
-    Here we check the current user can manage XCS, which is useful for projects like Buildasaur.
-    */
-    public func verifyXCSUserCanCreateBots(completion: (success: Bool, error: NSError?) -> ()) {
-        
-        //the way we check availability is first by logging out (does nothing if not logged in) and then
-        //calling getUserCanCreateBots, which, if necessary, automatically authenticates with Basic auth before resolving to true or false in JSON.
-        
-        self.logout { (success, error) -> () in
-            
-            if let error = error {
-                completion(success: false, error: error)
-                return
-            }
-            
-            self.getUserCanCreateBots { (canCreateBots, error) -> () in
-                
-                if let error = error {
-                    completion(success: false, error: error)
-                    return
-                }
-                
-                completion(success: canCreateBots, error: nil)
-            }
-        }
-    }
     
     /**
     Verifies that the blueprint contains valid Git credentials and that the blueprint contains a valid


### PR DESCRIPTION
As agreed in #47 I'm progressively moving **API routes** from rather long `XcodeServer` class file to separate `extension` files.

There's a new folder in project directory which holds those extensions. I've decided to follow well-know naming pattern from Objective-C (currently no standard for Swift has been set), so each `extension` will be named like: **XcodeServer+RoutesType.swift**.

One **important** thing, to categorize API routes I've decided to follow convention Apple is using in Xcode Server JS files which can be found if you go to:

```
/Applications/Xcode.app/Contents/Developer/usr/share/xcs/xcsd/route
```

IMHO, this is a good choice, so we can easily get back to those at any time 😉
