### PR TITLE
Added missing `Repository.swift` to iOS target.

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11129E591B4361C60037B689 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 		11376BD31B3A2F910005A681 /* XcodeServerSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 11376BD21B3A2F910005A681 /* XcodeServerSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		11376BD81B3A2FD90005A681 /* XcodeServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48DC1B2A5ADE0077ABEA /* XcodeServer.swift */; };
 		11376BD91B3A2FD90005A681 /* XcodeServerEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48DF1B2A5ADE0077ABEA /* XcodeServerEntity.swift */; };
@@ -761,7 +762,6 @@
 				11376BDE1B3A2FE30005A681 /* BotConfiguration.swift in Sources */,
 				11376BDF1B3A2FE30005A681 /* EmailConfiguration.swift in Sources */,
 				11376BE61B3A2FEB0005A681 /* CIServer.swift in Sources */,
-				70C2D8451B43273B008845FB /* XcodeServer+Auth.swift in Sources */,
 				11376BE71B3A2FEB0005A681 /* Errors.swift in Sources */,
 				11376BE81B3A2FEB0005A681 /* Server.swift in Sources */,
 				11376BE91B3A2FEB0005A681 /* XcodeServerConstants.swift in Sources */,
@@ -775,7 +775,6 @@
 				11376BD81B3A2FD90005A681 /* XcodeServer.swift in Sources */,
 				11376BD91B3A2FD90005A681 /* XcodeServerEntity.swift in Sources */,
 				11376BDA1B3A2FD90005A681 /* XcodeServerConfig.swift in Sources */,
-				70C2D84B1B432A55008845FB /* XcodeServer+Repository.swift in Sources */,
 				3A80C8091B3B639D0065C1C6 /* DeviceSpecification.swift in Sources */,
 				11376BDB1B3A2FD90005A681 /* XcodeServerEndpoints.swift in Sources */,
 				11376BDC1B3A2FD90005A681 /* XcodeServerFactory.swift in Sources */,
@@ -793,12 +792,12 @@
 				11FB71B11B34AF3300D57A52 /* Errors.swift in Sources */,
 				11FB71B21B34AF3300D57A52 /* Server.swift in Sources */,
 				11FB71B31B34AF3300D57A52 /* XcodeServerConstants.swift in Sources */,
+				11129E591B4361C60037B689 /* Repository.swift in Sources */,
 				11FB71A71B34AF2400D57A52 /* Bot.swift in Sources */,
 				70C2D8411B43273A008845FB /* XcodeServer+Auth.swift in Sources */,
 				11FB71A81B34AF2400D57A52 /* BotConfiguration.swift in Sources */,
 				11FB71A91B34AF2400D57A52 /* EmailConfiguration.swift in Sources */,
 				11FB71AA1B34AF2400D57A52 /* BotSchedule.swift in Sources */,
-				70E1413B1B409EA100AC98DB /* Repository.swift in Sources */,
 				3ABE68671B3AC3C500FA0A61 /* DeviceSpecification.swift in Sources */,
 				11FB71AB1B34AF2400D57A52 /* Trigger.swift in Sources */,
 				11FB71AC1B34AF2400D57A52 /* TriggerConditions.swift in Sources */,
@@ -808,7 +807,6 @@
 				11FB71A21B34AF1A00D57A52 /* XcodeServer.swift in Sources */,
 				11FB71A31B34AF1A00D57A52 /* XcodeServerEntity.swift in Sources */,
 				11FB71A41B34AF1A00D57A52 /* XcodeServerConfig.swift in Sources */,
-				70C2D84A1B432A55008845FB /* XcodeServer+Repository.swift in Sources */,
 				3A80C8071B3B62390065C1C6 /* ContainerExtensions.swift in Sources */,
 				11FB71A51B34AF1A00D57A52 /* XcodeServerEndpoints.swift in Sources */,
 				11FB71A61B34AF1A00D57A52 /* XcodeServerFactory.swift in Sources */,

--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11045C001B436A6B00B17DA3 /* XcodeServerConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */; };
 		11129E591B4361C60037B689 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7045917E1B4074CC00BA226C /* Repository.swift */; };
 		11376BD31B3A2F910005A681 /* XcodeServerSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 11376BD21B3A2F910005A681 /* XcodeServerSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		11376BD81B3A2FD90005A681 /* XcodeServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7B48DC1B2A5ADE0077ABEA /* XcodeServer.swift */; };
@@ -59,7 +60,6 @@
 		3A058A8E1B31595A0077FD47 /* BotParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A058A8D1B31595A0077FD47 /* BotParsingTests.swift */; };
 		3A058A931B315BB50077FD47 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A058A921B315BB50077FD47 /* TestUtils.swift */; };
 		3A06D5FD1B3C184400F0A6C5 /* XcodeServerEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */; };
-		3A06D5FE1B3C184700F0A6C5 /* XcodeServerConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */; };
 		3A06D5FF1B3C184D00F0A6C5 /* HTTPUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705D59A01B3AE502002521BA /* HTTPUtilsTests.swift */; };
 		3A06D6001B3C184F00F0A6C5 /* BotConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B21FF71B3AFB1D00EAD4EB /* BotConfigurationTests.swift */; };
 		3A13F30B1B404E7500C29D81 /* platforms.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A13F30A1B404E7500C29D81 /* platforms.json */; };
@@ -819,11 +819,11 @@
 			files = (
 				11FB71B81B34B00000D57A52 /* XcodeServerTests.swift in Sources */,
 				3A06D5FF1B3C184D00F0A6C5 /* HTTPUtilsTests.swift in Sources */,
+				11045C001B436A6B00B17DA3 /* XcodeServerConfigTests.swift in Sources */,
 				3A06D5FD1B3C184400F0A6C5 /* XcodeServerEntityTests.swift in Sources */,
 				70C2D8391B431F1E008845FB /* RepositoryTests.swift in Sources */,
 				11FB71B91B34B00000D57A52 /* BotParsingTests.swift in Sources */,
 				11FB71BA1B34B00000D57A52 /* TestUtils.swift in Sources */,
-				3A06D5FE1B3C184700F0A6C5 /* XcodeServerConfigTests.swift in Sources */,
 				3A06D6001B3C184F00F0A6C5 /* BotConfigurationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -948,6 +948,7 @@
 		11FB719A1B34AE7F00D57A52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -993,6 +994,7 @@
 		11FB719C1B34AE7F00D57A52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = XcodeServerSDKTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -60,7 +60,7 @@ public class XcodeServerConfig : JSONSerializable {
         - `InvalidHostProvided`: When the host provided doesn't produce a valid `URL`
         - `InvalidSchemeProvided`: When the provided scheme is not `HTTPS`
     */
-    public required init(var host: String, user: String?, password: String?) throws {
+    public required init(var host: String, user: String?=nil, password: String?=nil) throws {
         guard let url = NSURL(string: host) else {
             /*******************************************************************
              **   Had to be added to silence the compiler ¯\_(ツ)_/¯

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -55,7 +55,7 @@ class XcodeServerConfigTests: XCTestCase {
     
     func testInvalidSchemeProvided() {
         XCTempAssertThrowsSpecificError(ConfigurationErrors.InvalidSchemeProvided("")) {
-            try XcodeServerConfig(host: "http://127.0.0.1", user:nil, password:nil)
+            try XcodeServerConfig(host: "http://127.0.0.1")
         }
     }
     

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -53,6 +53,12 @@ class XcodeServerConfigTests: XCTestCase {
         }
     }
     
+    func testInvalidSchemeProvided() {
+        XCTempAssertThrowsSpecificError(ConfigurationErrors.InvalidSchemeProvided("")) {
+            try XcodeServerConfig(host: "http://127.0.0.1", user:nil, password:nil)
+        }
+    }
+    
     // MARK: Returning JSON
     func testJsonify() {
         XCTempAssertNoThrowError("Failed to initialize the server configuration") {


### PR DESCRIPTION
I rebased the latest changes to my fork and tried running the `iOS` test (out of sheer luck I choose this target) and noticed that the tests were failing because it couldn't find `Repository` class.

After checking the project and finding the file in it I noticed it was missing from the `iOS` target.

This is a pretty quick fix :wrench: :+1: 
