### PR TITLE
Tests/some cleanup

### DIFF
--- a/XcodeServerSDK/XcodeServerConfig.swift
+++ b/XcodeServerSDK/XcodeServerConfig.swift
@@ -8,11 +8,22 @@
 
 import Foundation
 
-public enum AvailabilityCheckState {
+public enum AvailabilityCheckState: Equatable {
     case Unchecked
     case Checking
     case Failed(NSError?)
     case Succeeded
+}
+
+/// Added `Equatable` to the enum to better test properties of this enum.
+public func == (a:AvailabilityCheckState, b:AvailabilityCheckState) -> Bool {
+    switch(a,b) {
+        case (.Unchecked, .Unchecked) : return true
+        case (.Checking, .Checking) : return true
+        case (.Failed(let fa), .Failed(let fb)) : return fa == fb
+        case (.Succeeded, .Succeeded) : return true
+        default: return false
+    }
 }
 
 /// Posible errors thrown by `XcodeServerConfig`

--- a/XcodeServerSDKTests/XcodeServerConfigTests.swift
+++ b/XcodeServerSDKTests/XcodeServerConfigTests.swift
@@ -13,32 +13,29 @@ class XcodeServerConfigTests: XCTestCase {
 
     // MARK: Initialization testing
     func testManualInit() {
-        do {
+        XCTempAssertNoThrowError("Failed to initialize the server configuration") {
             let config = try XcodeServerConfig(host: "127.0.0.1", user: "ICanCreateBots", password: "superSecr3t")
             
             XCTAssertEqual(config.host, "https://127.0.0.1", "Should create proper host address")
             XCTAssertEqual(config.user!, "ICanCreateBots")
             XCTAssertEqual(config.password!, "superSecr3t")
-        } catch {
-            XCTFail("Failed to initialize the server configuration: \(error)")
+            XCTAssertTrue(config.availabilityState == AvailabilityCheckState.Unchecked)
         }
     }
     
     func testDictionaryInit() {
-        let json = [
-            "host": "https://127.0.0.1",
-            "user": "ICanCreateBots",
-            "password": "superSecr3t"
-        ]
-        
-        do {
+        XCTempAssertNoThrowError("Failed to initialize the server configuration") {
+            let json = [
+                "host": "https://127.0.0.1",
+                "user": "ICanCreateBots",
+                "password": "superSecr3t"
+            ]
+            
             let config = try XcodeServerConfig(json: json)
             
             XCTAssertEqual(config!.host, "https://127.0.0.1", "Should create proper host address")
             XCTAssertEqual(config!.user!, "ICanCreateBots")
             XCTAssertEqual(config!.password!, "superSecr3t")
-        } catch {
-            XCTFail("Failed to initialize the server configuration: \(error)")
         }
     }
     
@@ -54,7 +51,7 @@ class XcodeServerConfigTests: XCTestCase {
     }
     
     func testInvalidSchemeProvided() {
-        XCTempAssertThrowsSpecificError(ConfigurationErrors.InvalidSchemeProvided("")) {
+        XCTempAssertThrowsSpecificError(ConfigurationErrors.InvalidSchemeProvided("Xcode Server generally uses https, please double check your hostname")) {
             try XcodeServerConfig(host: "http://127.0.0.1")
         }
     }


### PR DESCRIPTION
# Done
- Implemented `Equatable` on enum for tests
- Rewriting some test to use XCTempAsserts
  - Some tests had my previous implementation of `throws` tests; I changed the code to use the better more cleaner assertions.
  - Also added a check to verify that the `availabilityState` is being defaulted to `.Unchecked` after a fresh init.
