### PR TITLE
Backwards compatible parsing of BuildResultSummary

### DIFF
--- a/XcodeServerSDK/Server Entities/Integration.swift
+++ b/XcodeServerSDK/Server Entities/Integration.swift
@@ -138,8 +138,8 @@ public class BuildResultSummary : XcodeServerEntity {
         self.errorChange = json.intForKey("errorChange")
         self.improvedPerfTestCount = json.intForKey("improvedPerfTestCount")
         self.analyzerWarningChange = json.intForKey("analyzerWarningChange")
-        self.codeCoveragePercentage = json.intForKey("codeCoveragePercentage")
-        self.codeCoveragePercentageDelta = json.intForKey("codeCoveragePercentageDelta")
+        self.codeCoveragePercentage = json.optionalIntForKey("codeCoveragePercentage") ?? 0
+        self.codeCoveragePercentageDelta = json.optionalIntForKey("codeCoveragePercentageDelta") ?? 0
         
         super.init(json: json)
     }


### PR DESCRIPTION
a bit of backwards compatibility never hurts (we don't want buildasaur crashing when it receives integration results from Xcode 6, even when served by Xcode 7 - the format will be old)
