### PR TITLE
Create request tests

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		707D089A1B2C6986003900F3 /* BotSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D08991B2C6986003900F3 /* BotSchedule.swift */; };
 		707D089C1B2C69C4003900F3 /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D089B1B2C69C4003900F3 /* Trigger.swift */; };
 		707D089E1B2C6A1F003900F3 /* TriggerConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D089D1B2C6A1F003900F3 /* TriggerConditions.swift */; };
+		7088E7CC1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7088E7CB1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift */; };
+		7088E7CD1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7088E7CB1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift */; };
 		7089CBB81B53DC9D006C9EC5 /* PlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7089CBB71B53DC9D006C9EC5 /* PlatformTests.swift */; };
 		7089CBB91B53DC9D006C9EC5 /* PlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7089CBB71B53DC9D006C9EC5 /* PlatformTests.swift */; };
 		7089CBBB1B53DD7A006C9EC5 /* get_platforms.json in Resources */ = {isa = PBXBuildFile; fileRef = 7089CBBA1B53DD7A006C9EC5 /* get_platforms.json */; };
@@ -220,6 +222,7 @@
 		707D08991B2C6986003900F3 /* BotSchedule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BotSchedule.swift; sourceTree = "<group>"; };
 		707D089B1B2C69C4003900F3 /* Trigger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trigger.swift; sourceTree = "<group>"; };
 		707D089D1B2C6A1F003900F3 /* TriggerConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerConditions.swift; sourceTree = "<group>"; };
+		7088E7CB1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerEndpointsTests.swift; sourceTree = "<group>"; };
 		7089CBB71B53DC9D006C9EC5 /* PlatformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformTests.swift; sourceTree = "<group>"; };
 		7089CBBA1B53DD7A006C9EC5 /* get_platforms.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_platforms.json; sourceTree = "<group>"; };
 		709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerEntityTests.swift; sourceTree = "<group>"; };
@@ -374,6 +377,7 @@
 				709ED67F1B3608FC00A06038 /* XcodeServerConfigTests.swift */,
 				709ED67B1B35FD3F00A06038 /* XcodeServerEntityTests.swift */,
 				3A7B48CC1B2A5AC40077ABEA /* XcodeServerTests.swift */,
+				7088E7CB1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift */,
 				3AD14B771B3F71C600BFDEAA /* Casettes */,
 				3A058A911B31596E0077FD47 /* Data */,
 				3A7B48CA1B2A5AC40077ABEA /* Supporting Files */,
@@ -985,6 +989,7 @@
 				70C2D8391B431F1E008845FB /* RepositoryTests.swift in Sources */,
 				11FB71B91B34B00000D57A52 /* BotParsingTests.swift in Sources */,
 				3AC47F471B587C67008C4E42 /* IntegrationTests.swift in Sources */,
+				7088E7CD1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift in Sources */,
 				703FED521B53AD1B00943876 /* DevicesTests.swift in Sources */,
 				11FB71BA1B34B00000D57A52 /* TestUtils.swift in Sources */,
 				7089CBB91B53DC9D006C9EC5 /* PlatformTests.swift in Sources */,
@@ -1036,6 +1041,7 @@
 				3A058A931B315BB50077FD47 /* TestUtils.swift in Sources */,
 				3A7B48CD1B2A5AC40077ABEA /* XcodeServerTests.swift in Sources */,
 				3AC47F461B587C67008C4E42 /* IntegrationTests.swift in Sources */,
+				7088E7CC1B5CE3E400C3B694 /* XcodeServerEndpointsTests.swift in Sources */,
 				703FED511B53AD1B00943876 /* DevicesTests.swift in Sources */,
 				709ED6801B3608FC00A06038 /* XcodeServerConfigTests.swift in Sources */,
 				7089CBB81B53DC9D006C9EC5 /* PlatformTests.swift in Sources */,

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -1,0 +1,28 @@
+//
+//  XcodeServerEndpointsTests.swift
+//  XcodeServerSDK
+//
+//  Created by Mateusz Zając on 20/07/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+import BuildaUtils
+@testable import XcodeServerSDK
+
+class XcodeServerEndpointsTests: XCTestCase {
+
+    let serverConfig = try! XcodeServerConfig(host: "https://127.0.0.1", user: "test", password: "test")
+    var endpoints: XcodeServerEndPoints?
+    
+    override func setUp() {
+        self.endpoints = XcodeServerEndPoints(serverConfig: serverConfig)
+    }
+    
+    // If malformed URL is passed to request creation function it should early exit and retur nil
+    func testMalformedURLCreation() {
+        let expectation = endpoints?.createRequest(.GET, endpoint: .Bots, params: ["test": "test"], query: ["test//http\\": "!test"], body: ["test": "test"], doBasicAuth: true)
+        XCTAssertNil(expectation, "Shouldn't create request from malformed URL")
+    }
+
+}


### PR DESCRIPTION
Oi! 🇬🇧

I've created test suite for `XcodeServerEndpoints` with purpose of testing `createRequest()` but it looks like it's mostly tested (or at least covered in other tests), so I've only created **test case** for malformed URLs passed to this method.

We're missing code coverage for those lines:

``` swift
catch {
    let error = error as NSError
    Log.error("Parsing error \(error.description)")
    return nil
}
```

but it's complicated as I can't invent any failable case for `NSJSONSerialization.dataWithJSONObject()` as earlier we make sure we pass `NSDictionary` and any valid dictionary will be a valid JSON in that case.

---

Still no update for `guard` statement bug and code put directly after `guard` is never marked in test coverage... 😭
