### PR TITLE
XcodeServerEndpoints.endpointURL tests

### DIFF
--- a/XcodeServerSDK/XcodeServer.swift
+++ b/XcodeServerSDK/XcodeServer.swift
@@ -13,9 +13,9 @@ import BuildaUtils
 public class XcodeServer : CIServer {
     
     public let config: XcodeServerConfig
-    let endpoints: XcodeServerEndPoints
+    let endpoints: XcodeServerEndpoints
     
-    public init(config: XcodeServerConfig, endpoints: XcodeServerEndPoints) {
+    public init(config: XcodeServerConfig, endpoints: XcodeServerEndpoints) {
         
         self.config = config
         self.endpoints = endpoints
@@ -116,7 +116,7 @@ public extension XcodeServer {
     - parameter body:       POST method request body.
     - parameter completion: Completion.
     */
-    internal func sendRequestWithMethod(method: HTTP.Method, endpoint: XcodeServerEndPoints.Endpoint, params: [String: String]?, query: [String: String]?, body: NSDictionary?, completion: HTTP.Completion) {
+    internal func sendRequestWithMethod(method: HTTP.Method, endpoint: XcodeServerEndpoints.Endpoint, params: [String: String]?, query: [String: String]?, body: NSDictionary?, completion: HTTP.Completion) {
         
         var allParams = [
             "method": method.rawValue

--- a/XcodeServerSDK/XcodeServerEndpoints.swift
+++ b/XcodeServerSDK/XcodeServerEndpoints.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BuildaUtils
 
-public class XcodeServerEndPoints {
+public class XcodeServerEndpoints {
     
     enum Endpoint {
         case Bots

--- a/XcodeServerSDK/XcodeServerEndpoints.swift
+++ b/XcodeServerSDK/XcodeServerEndpoints.swift
@@ -37,7 +37,7 @@ public class XcodeServerEndpoints {
         self.serverConfig = serverConfig
     }
     
-    private func endpointURL(endpoint: Endpoint, params: [String: String]? = nil) -> String {
+    func endpointURL(endpoint: Endpoint, params: [String: String]? = nil) -> String {
         
         let base = "/api"
         

--- a/XcodeServerSDK/XcodeServerFactory.swift
+++ b/XcodeServerSDK/XcodeServerFactory.swift
@@ -12,7 +12,7 @@ public class XcodeServerFactory {
     
     public class func server(config: XcodeServerConfig) -> XcodeServer {
         
-        let endpoints = XcodeServerEndPoints(serverConfig: config)
+        let endpoints = XcodeServerEndpoints(serverConfig: config)
         let server = XcodeServer(config: config, endpoints: endpoints)
         
         return server

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -16,6 +16,7 @@ class XcodeServerEndpointsTests: XCTestCase {
     var endpoints: XcodeServerEndpoints?
     
     override func setUp() {
+        super.setUp()
         self.endpoints = XcodeServerEndpoints(serverConfig: serverConfig)
     }
     

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -155,4 +155,77 @@ class XcodeServerEndpointsTests: XCTestCase {
             XCTAssertEqual(url!, "/api/integrations/integrationValue", "endpointURL(.Integrations, \(params)) should return \"/api/integrations/integrationValue\"")
         }
     }
+    
+    // MARK: endpointURL(.CancelIntegration)
+    
+    func testEndpointURLCreationForCancelIntegrationWithoutParams() {
+        let url = self.endpoints?.endpointURL(.CancelIntegration)
+        XCTAssertEqual(url!, "/api/integrations/cancel", "endpointURL(.CancelIntegration) should return \"/api/integrations\"")
+    }
+    
+    func testEndpointURLCreationForBotsBotIntegrationsCancel() {
+        let paramsArray = [
+            [
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue/integrations/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/bots/botValue/integrations/cancel\"")
+        }
+    }
+    
+    func testEndpointURLCreationForBotsBotRevIntegrationsCancel() {
+        let paramsArray = [
+            [
+                "rev": "revValue",
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "rev": "revValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "rev": "revValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue/revValue/integrations/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/bots/botValue/revValue/integrations/cancel\"")
+        }
+    }
+    
+    func testEndpointURLCreationForIntegrationsIntegrationCancel() {
+        let paramsArray = [
+            [
+                "integration": "integrationValue",
+            ],
+            [
+                "otherKey": "otherValue",
+                "integration": "integrationValue"
+            ],
+            [
+                "rev": "revValue",
+                "otherKey": "otherValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
+            XCTAssertEqual(url!, "/api/integrations/integrationValue/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/integrations/integrationValue/cancel\"")
+        }
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -82,4 +82,77 @@ class XcodeServerEndpointsTests: XCTestCase {
             XCTAssertEqual(url!, "/api/bots/botValue/revValue", "endpointURL(.Bots, \(params)) should return \"/api/bots/botValue/revValue\"")
         }
     }
+    
+    // MARK: endpointURL(.Integrations)
+    
+    func testEndpointURLCreationForIntegrationsWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Integrations)
+        XCTAssertEqual(url!, "/api/integrations", "endpointURL(.Integrations) should return \"/api/integrations\"")
+    }
+    
+    func testEndpointURLCreationForBotsBotIntegrations() {
+        let paramsArray = [
+            [
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Integrations, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue/integrations", "endpointURL(.Integrations, \(params)) should return \"/api/bots/botValue/integrations\"")
+        }
+    }
+    
+    func testEndpointURLCreationForBotsBotRevIntegrations() {
+        let paramsArray = [
+            [
+                "rev": "revValue",
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "rev": "revValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "rev": "revValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Integrations, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue/revValue/integrations", "endpointURL(.Integrations, \(params)) should return \"/api/bots/botValue/revValue/integrations\"")
+        }
+    }
+    
+    func testEndpointURLCreationForIntegrationsIntegration() {
+        let paramsArray = [
+            [
+                "integration": "integrationValue",
+            ],
+            [
+                "otherKey": "otherValue",
+                "integration": "integrationValue"
+            ],
+            [
+                "rev": "revValue",
+                "otherKey": "otherValue",
+                "integration": "integrationValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Integrations, params: params)
+            XCTAssertEqual(url!, "/api/integrations/integrationValue", "endpointURL(.Integrations, \(params)) should return \"/api/integrations/integrationValue\"")
+        }
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -264,4 +264,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.UserCanCreateBots, params: params)
         XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots, \(params)) should return \"/api/auth/isBotCreator\"")
     }
+    
+    // MARK: endpointURL(.Login)
+    
+    func testEndpointURLCreationForLoginWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Login)
+        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login) should return \"/api/auth/login\"")
+    }
+    
+    func testEndpointURLCreationForAuthLogin() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.Login, params: params)
+        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login, \(params)) should return \"/api/auth/login\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -13,10 +13,10 @@ import BuildaUtils
 class XcodeServerEndpointsTests: XCTestCase {
 
     let serverConfig = try! XcodeServerConfig(host: "https://127.0.0.1", user: "test", password: "test")
-    var endpoints: XcodeServerEndPoints?
+    var endpoints: XcodeServerEndpoints?
     
     override func setUp() {
-        self.endpoints = XcodeServerEndPoints(serverConfig: serverConfig)
+        self.endpoints = XcodeServerEndpoints(serverConfig: serverConfig)
     }
     
     // If malformed URL is passed to request creation function it should early exit and retur nil

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -336,4 +336,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.SCM_Branches, params: params)
         XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches, \(params)) should return \"/api/scm/branches\"")
     }
+    
+    // MARK: endpointURL(.Repositories)
+    
+    func testEndpointURLCreationForRepositoriesWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Repositories)
+        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories) should return \"/api/repositories\"")
+    }
+    
+    func testEndpointURLCreationForRepositories() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.Repositories, params: params)
+        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories, \(params)) should return \"/api/repositories\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -228,4 +228,22 @@ class XcodeServerEndpointsTests: XCTestCase {
             XCTAssertEqual(url!, "/api/integrations/integrationValue/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/integrations/integrationValue/cancel\"")
         }
     }
+    
+    // MARK: endpointURL(.Devices)
+    
+    func testEndpointURLCreationForDevicesWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Devices)
+        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices) should return \"/api/devices\"")
+    }
+    
+    func testEndpointURLCreationForDevices() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.Devices, params: params)
+        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices, \(params)) should return \"/api/devices\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -300,4 +300,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.Logout, params: params)
         XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout, \(params)) should return \"/api/auth/logout\"")
     }
+    
+    // MARK: endpointURL(.Platforms)
+    
+    func testEndpointURLCreationForPlatformsWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Platforms)
+        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms) should return \"/api/platforms\"")
+    }
+    
+    func testEndpointURLCreationForPlatforms() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.Platforms, params: params)
+        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms, \(params)) should return \"/api/platforms\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -25,5 +25,61 @@ class XcodeServerEndpointsTests: XCTestCase {
         let expectation = endpoints?.createRequest(.GET, endpoint: .Bots, params: ["test": "test"], query: ["test//http\\": "!test"], body: ["test": "test"], doBasicAuth: true)
         XCTAssertNil(expectation, "Shouldn't create request from malformed URL")
     }
-
+    
+    // MARK: endpointURL(.Bots)
+    
+    func testEndpointURLCreationForBotsWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Bots)
+        XCTAssertEqual(url!, "/api/bots", "endpointURL(.Bots) should return \"/api/bots\"")
+    }
+    
+    func testEndpointURLCreationForBots() {
+        let paramsArray = [
+            [
+                "key": "value"
+            ],
+            [
+                "key": "value",
+                "rev": "rev"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Bots, params: params)
+            XCTAssertEqual(url!, "/api/bots", "endpointURL(.Bots, \(params)) should return \"/api/bots\"")
+        }
+    }
+    
+    func testEndpointURLCreationForBotsBot() {
+        let paramsArray = [
+            [
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Bots, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue", "endpointURL(.Bots, \(params)) should return \"/api/bots/botValue\"")
+        }
+    }
+    
+    func testEndpointURLCreationForBotsBotRev() {
+        let paramsArray = [
+            [
+                "rev": "revValue",
+                "bot": "botValue"
+            ],
+            [
+                "otherKey": "otherValue",
+                "bot": "botValue",
+                "rev": "revValue"
+            ]
+        ]
+        for params in paramsArray {
+            let url = self.endpoints?.endpointURL(.Bots, params: params)
+            XCTAssertEqual(url!, "/api/bots/botValue/revValue", "endpointURL(.Bots, \(params)) should return \"/api/bots/botValue/revValue\"")
+        }
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -160,7 +160,7 @@ class XcodeServerEndpointsTests: XCTestCase {
     
     func testEndpointURLCreationForCancelIntegrationWithoutParams() {
         let url = self.endpoints?.endpointURL(.CancelIntegration)
-        XCTAssertEqual(url!, "/api/integrations/cancel", "endpointURL(.CancelIntegration) should return \"/api/integrations\"")
+        XCTAssertEqual(url!, "/api/integrations/cancel", "endpointURL(.CancelIntegration) should return \"/api/integrations/cancel\"")
     }
     
     func testEndpointURLCreationForBotsBotIntegrationsCancel() {

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -14,10 +14,17 @@ class XcodeServerEndpointsTests: XCTestCase {
 
     let serverConfig = try! XcodeServerConfig(host: "https://127.0.0.1", user: "test", password: "test")
     var endpoints: XcodeServerEndpoints?
+    var randomParams: [String: String]?
     
     override func setUp() {
         super.setUp()
         self.endpoints = XcodeServerEndpoints(serverConfig: serverConfig)
+        self.randomParams = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
     }
     
     // If malformed URL is passed to request creation function it should early exit and retur nil
@@ -237,14 +244,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForDevices() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.Devices, params: params)
-        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices, \(params)) should return \"/api/devices\"")
+        let url = self.endpoints?.endpointURL(.Devices, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices, \(self.randomParams)) should return \"/api/devices\"")
     }
     
     // MARK: endpointURL(.UserCanCreateBots)
@@ -255,14 +256,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForAuthIsBotCreator() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.UserCanCreateBots, params: params)
-        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots, \(params)) should return \"/api/auth/isBotCreator\"")
+        let url = self.endpoints?.endpointURL(.UserCanCreateBots, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots, \(self.randomParams)) should return \"/api/auth/isBotCreator\"")
     }
     
     // MARK: endpointURL(.Login)
@@ -273,14 +268,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForAuthLogin() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.Login, params: params)
-        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login, \(params)) should return \"/api/auth/login\"")
+        let url = self.endpoints?.endpointURL(.Login, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login, \(self.randomParams)) should return \"/api/auth/login\"")
     }
     
     // MARK: endpointURL(.Logout)
@@ -291,14 +280,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForAuthLogout() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.Logout, params: params)
-        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout, \(params)) should return \"/api/auth/logout\"")
+        let url = self.endpoints?.endpointURL(.Logout, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout, \(self.randomParams)) should return \"/api/auth/logout\"")
     }
     
     // MARK: endpointURL(.Platforms)
@@ -309,14 +292,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForPlatforms() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.Platforms, params: params)
-        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms, \(params)) should return \"/api/platforms\"")
+        let url = self.endpoints?.endpointURL(.Platforms, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms, \(self.randomParams)) should return \"/api/platforms\"")
     }
     
     // MARK: endpointURL(.SCM_Branches)
@@ -327,14 +304,8 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForSCMBranches() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.SCM_Branches, params: params)
-        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches, \(params)) should return \"/api/scm/branches\"")
+        let url = self.endpoints?.endpointURL(.SCM_Branches, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches, \(self.randomParams)) should return \"/api/scm/branches\"")
     }
     
     // MARK: endpointURL(.Repositories)
@@ -345,13 +316,7 @@ class XcodeServerEndpointsTests: XCTestCase {
     }
     
     func testEndpointURLCreationForRepositories() {
-        let params = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
-        let url = self.endpoints?.endpointURL(.Repositories, params: params)
-        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories, \(params)) should return \"/api/repositories\"")
+        let url = self.endpoints?.endpointURL(.Repositories, params: self.randomParams)
+        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories, \(self.randomParams)) should return \"/api/repositories\"")
     }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -318,4 +318,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.Platforms, params: params)
         XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms, \(params)) should return \"/api/platforms\"")
     }
+    
+    // MARK: endpointURL(.SCM_Branches)
+    
+    func testEndpointURLCreationForSCMBranchesWithoutParams() {
+        let url = self.endpoints?.endpointURL(.SCM_Branches)
+        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches) should return \"/api/scm/branches\"")
+    }
+    
+    func testEndpointURLCreationForSCMBranches() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.SCM_Branches, params: params)
+        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches, \(params)) should return \"/api/scm/branches\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -282,4 +282,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.Login, params: params)
         XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login, \(params)) should return \"/api/auth/login\"")
     }
+    
+    // MARK: endpointURL(.Logout)
+    
+    func testEndpointURLCreationForLogoutWithoutParams() {
+        let url = self.endpoints?.endpointURL(.Logout)
+        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout) should return \"/api/auth/logout\"")
+    }
+    
+    func testEndpointURLCreationForAuthLogout() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.Logout, params: params)
+        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout, \(params)) should return \"/api/auth/logout\"")
+    }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -14,17 +14,10 @@ class XcodeServerEndpointsTests: XCTestCase {
 
     let serverConfig = try! XcodeServerConfig(host: "https://127.0.0.1", user: "test", password: "test")
     var endpoints: XcodeServerEndpoints?
-    var randomParams: [String: String]?
     
     override func setUp() {
         super.setUp()
         self.endpoints = XcodeServerEndpoints(serverConfig: serverConfig)
-        self.randomParams = [
-            "rev": "revValue",
-            "bot": "botValue",
-            "integration": "integrationValue",
-            "otherKey": "otherValue"
-        ]
     }
     
     // If malformed URL is passed to request creation function it should early exit and retur nil
@@ -35,288 +28,121 @@ class XcodeServerEndpointsTests: XCTestCase {
     
     // MARK: endpointURL(.Bots)
     
-    func testEndpointURLCreationForBotsWithoutParams() {
+    func testEndpointURLCreationForBotsPath() {
+        let expectation = "/api/bots"
         let url = self.endpoints?.endpointURL(.Bots)
-        XCTAssertEqual(url!, "/api/bots", "endpointURL(.Bots) should return \"/api/bots\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Bots) should return \(expectation)")
     }
     
-    func testEndpointURLCreationForBots() {
-        let paramsArray = [
-            [
-                "key": "value"
-            ],
-            [
-                "key": "value",
-                "rev": "rev"
-            ]
+    func testEndpointURLCreationForBotsBotPath() {
+        let expectation = "/api/bots/bot_id"
+        let params = [
+            "bot": "bot_id"
         ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Bots, params: params)
-            XCTAssertEqual(url!, "/api/bots", "endpointURL(.Bots, \(params)) should return \"/api/bots\"")
-        }
+        let url = self.endpoints?.endpointURL(.Bots, params: params)
+        XCTAssertEqual(url!, expectation, "endpointURL(.Bots, \(params)) should return \(expectation)")
     }
     
-    func testEndpointURLCreationForBotsBot() {
-        let paramsArray = [
-            [
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue"
-            ]
+    func testEndpointURLCreationForBotsBotRevPath() {
+        let expectation = "/api/bots/bot_id/rev_id"
+        let params = [
+            "bot": "bot_id",
+            "rev": "rev_id"
         ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Bots, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue", "endpointURL(.Bots, \(params)) should return \"/api/bots/botValue\"")
-        }
-    }
-    
-    func testEndpointURLCreationForBotsBotRev() {
-        let paramsArray = [
-            [
-                "rev": "revValue",
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "rev": "revValue"
-            ]
-        ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Bots, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue/revValue", "endpointURL(.Bots, \(params)) should return \"/api/bots/botValue/revValue\"")
-        }
+        let url = self.endpoints?.endpointURL(.Bots, params: params)
+        XCTAssertEqual(url!, expectation, "endpointURL(.Bots, \(params)) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Integrations)
     
-    func testEndpointURLCreationForIntegrationsWithoutParams() {
+    func testEndpointURLCreationForIntegrationsPath() {
+        let expectation = "/api/integrations"
         let url = self.endpoints?.endpointURL(.Integrations)
-        XCTAssertEqual(url!, "/api/integrations", "endpointURL(.Integrations) should return \"/api/integrations\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Integrations) should return \(expectation)")
     }
     
-    func testEndpointURLCreationForBotsBotIntegrations() {
-        let paramsArray = [
-            [
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "integration": "integrationValue"
-            ]
+    func testEndpointURLCreationForIntegrationsIntegrationPath() {
+        let expectation = "/api/integrations/integration_id"
+        let params = [
+            "integration": "integration_id"
         ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Integrations, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue/integrations", "endpointURL(.Integrations, \(params)) should return \"/api/bots/botValue/integrations\"")
-        }
+        let url = self.endpoints?.endpointURL(.Integrations, params: params)
+        XCTAssertEqual(url!, expectation, "endpointURL(.Integrations, \(params)) should return \(expectation)")
     }
     
-    func testEndpointURLCreationForBotsBotRevIntegrations() {
-        let paramsArray = [
-            [
-                "rev": "revValue",
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "rev": "revValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "rev": "revValue",
-                "integration": "integrationValue"
-            ]
+    func testEndpointURLCreationForBotsBotIntegrationsPath() {
+        let expectation = "/api/bots/bot_id/integrations"
+        let params = [
+            "bot": "bot_id"
         ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Integrations, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue/revValue/integrations", "endpointURL(.Integrations, \(params)) should return \"/api/bots/botValue/revValue/integrations\"")
-        }
-    }
-    
-    func testEndpointURLCreationForIntegrationsIntegration() {
-        let paramsArray = [
-            [
-                "integration": "integrationValue",
-            ],
-            [
-                "otherKey": "otherValue",
-                "integration": "integrationValue"
-            ],
-            [
-                "rev": "revValue",
-                "otherKey": "otherValue",
-                "integration": "integrationValue"
-            ]
-        ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.Integrations, params: params)
-            XCTAssertEqual(url!, "/api/integrations/integrationValue", "endpointURL(.Integrations, \(params)) should return \"/api/integrations/integrationValue\"")
-        }
+        let url = self.endpoints?.endpointURL(.Integrations, params: params)
+        XCTAssertEqual(url!, expectation, "endpointURL(.Integrations, \(params)) should return \(expectation)")
     }
     
     // MARK: endpointURL(.CancelIntegration)
     
-    func testEndpointURLCreationForCancelIntegrationWithoutParams() {
-        let url = self.endpoints?.endpointURL(.CancelIntegration)
-        XCTAssertEqual(url!, "/api/integrations/cancel", "endpointURL(.CancelIntegration) should return \"/api/integrations/cancel\"")
-    }
-    
-    func testEndpointURLCreationForBotsBotIntegrationsCancel() {
-        let paramsArray = [
-            [
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "integration": "integrationValue"
-            ]
+    func testEndpointURLCreationForIntegrationsIntegrationCancelPath() {
+        let expectation = "/api/integrations/integration_id/cancel"
+        let params = [
+            "integration": "integration_id"
         ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue/integrations/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/bots/botValue/integrations/cancel\"")
-        }
-    }
-    
-    func testEndpointURLCreationForBotsBotRevIntegrationsCancel() {
-        let paramsArray = [
-            [
-                "rev": "revValue",
-                "bot": "botValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "rev": "revValue"
-            ],
-            [
-                "otherKey": "otherValue",
-                "bot": "botValue",
-                "rev": "revValue",
-                "integration": "integrationValue"
-            ]
-        ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
-            XCTAssertEqual(url!, "/api/bots/botValue/revValue/integrations/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/bots/botValue/revValue/integrations/cancel\"")
-        }
-    }
-    
-    func testEndpointURLCreationForIntegrationsIntegrationCancel() {
-        let paramsArray = [
-            [
-                "integration": "integrationValue",
-            ],
-            [
-                "otherKey": "otherValue",
-                "integration": "integrationValue"
-            ],
-            [
-                "rev": "revValue",
-                "otherKey": "otherValue",
-                "integration": "integrationValue"
-            ]
-        ]
-        for params in paramsArray {
-            let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
-            XCTAssertEqual(url!, "/api/integrations/integrationValue/cancel", "endpointURL(.CancelIntegration, \(params)) should return \"/api/integrations/integrationValue/cancel\"")
-        }
+        let url = self.endpoints?.endpointURL(.CancelIntegration, params: params)
+        XCTAssertEqual(url!, expectation, "endpointURL(.CancelIntegration, \(params)) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Devices)
     
-    func testEndpointURLCreationForDevicesWithoutParams() {
+    func testEndpointURLCreationForDevicesPath() {
+        let expectation = "/api/devices"
         let url = self.endpoints?.endpointURL(.Devices)
-        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices) should return \"/api/devices\"")
-    }
-    
-    func testEndpointURLCreationForDevices() {
-        let url = self.endpoints?.endpointURL(.Devices, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices, \(self.randomParams)) should return \"/api/devices\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Devices) should return \(expectation)")
     }
     
     // MARK: endpointURL(.UserCanCreateBots)
     
-    func testEndpointURLCreationForUserCanCreateBotsWithoutParams() {
+    func testEndpointURLCreationForAuthIsBotCreatorPath() {
+        let expectation = "/api/auth/isBotCreator"
         let url = self.endpoints?.endpointURL(.UserCanCreateBots)
-        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots) should return \"/api/auth/isBotCreator\"")
-    }
-    
-    func testEndpointURLCreationForAuthIsBotCreator() {
-        let url = self.endpoints?.endpointURL(.UserCanCreateBots, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots, \(self.randomParams)) should return \"/api/auth/isBotCreator\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.UserCanCreateBots) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Login)
     
-    func testEndpointURLCreationForLoginWithoutParams() {
+    func testEndpointURLCreationForAuthLoginPath() {
+        let expectation = "/api/auth/login"
         let url = self.endpoints?.endpointURL(.Login)
-        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login) should return \"/api/auth/login\"")
-    }
-    
-    func testEndpointURLCreationForAuthLogin() {
-        let url = self.endpoints?.endpointURL(.Login, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/auth/login", "endpointURL(.Login, \(self.randomParams)) should return \"/api/auth/login\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Login) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Logout)
     
-    func testEndpointURLCreationForLogoutWithoutParams() {
+    func testEndpointURLCreationForAuthLogoutPath() {
+        let expectation = "/api/auth/logout"
         let url = self.endpoints?.endpointURL(.Logout)
-        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout) should return \"/api/auth/logout\"")
-    }
-    
-    func testEndpointURLCreationForAuthLogout() {
-        let url = self.endpoints?.endpointURL(.Logout, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/auth/logout", "endpointURL(.Logout, \(self.randomParams)) should return \"/api/auth/logout\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Logout) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Platforms)
     
-    func testEndpointURLCreationForPlatformsWithoutParams() {
+    func testEndpointURLCreationForPlatformsPath() {
+        let expectation = "/api/platforms"
         let url = self.endpoints?.endpointURL(.Platforms)
-        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms) should return \"/api/platforms\"")
-    }
-    
-    func testEndpointURLCreationForPlatforms() {
-        let url = self.endpoints?.endpointURL(.Platforms, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/platforms", "endpointURL(.Platforms, \(self.randomParams)) should return \"/api/platforms\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Platforms) should return \(expectation)")
     }
     
     // MARK: endpointURL(.SCM_Branches)
     
-    func testEndpointURLCreationForSCMBranchesWithoutParams() {
+    func testEndpointURLCreationForScmBranchesPath() {
+        let expectation = "/api/scm/branches"
         let url = self.endpoints?.endpointURL(.SCM_Branches)
-        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches) should return \"/api/scm/branches\"")
-    }
-    
-    func testEndpointURLCreationForSCMBranches() {
-        let url = self.endpoints?.endpointURL(.SCM_Branches, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/scm/branches", "endpointURL(.SCM_Branches, \(self.randomParams)) should return \"/api/scm/branches\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.SCM_Branches) should return \(expectation)")
     }
     
     // MARK: endpointURL(.Repositories)
     
-    func testEndpointURLCreationForRepositoriesWithoutParams() {
+    func testEndpointURLCreationForRepositoriesPath() {
+        let expectation = "/api/repositories"
         let url = self.endpoints?.endpointURL(.Repositories)
-        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories) should return \"/api/repositories\"")
-    }
-    
-    func testEndpointURLCreationForRepositories() {
-        let url = self.endpoints?.endpointURL(.Repositories, params: self.randomParams)
-        XCTAssertEqual(url!, "/api/repositories", "endpointURL(.Repositories, \(self.randomParams)) should return \"/api/repositories\"")
+        XCTAssertEqual(url!, expectation, "endpointURL(.Repositories) should return \(expectation)")
     }
 }

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -47,7 +47,8 @@ class XcodeServerEndpointsTests: XCTestCase {
         let expectation = "/api/bots/bot_id/rev_id"
         let params = [
             "bot": "bot_id",
-            "rev": "rev_id"
+            "rev": "rev_id",
+            "method": "DELETE"
         ]
         let url = self.endpoints?.endpointURL(.Bots, params: params)
         XCTAssertEqual(url!, expectation, "endpointURL(.Bots, \(params)) should return \(expectation)")

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -246,4 +246,22 @@ class XcodeServerEndpointsTests: XCTestCase {
         let url = self.endpoints?.endpointURL(.Devices, params: params)
         XCTAssertEqual(url!, "/api/devices", "endpointURL(.Devices, \(params)) should return \"/api/devices\"")
     }
+    
+    // MARK: endpointURL(.UserCanCreateBots)
+    
+    func testEndpointURLCreationForUserCanCreateBotsWithoutParams() {
+        let url = self.endpoints?.endpointURL(.UserCanCreateBots)
+        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots) should return \"/api/auth/isBotCreator\"")
+    }
+    
+    func testEndpointURLCreationForAuthIsBotCreator() {
+        let params = [
+            "rev": "revValue",
+            "bot": "botValue",
+            "integration": "integrationValue",
+            "otherKey": "otherValue"
+        ]
+        let url = self.endpoints?.endpointURL(.UserCanCreateBots, params: params)
+        XCTAssertEqual(url!, "/api/auth/isBotCreator", "endpointURL(.UserCanCreateBots, \(params)) should return \"/api/auth/isBotCreator\"")
+    }
 }


### PR DESCRIPTION
I've created tests for endpointURL method from XcodeServerEndpoints class. I set access level of XcodeServerEndpoints.endpointURL method as internal as we discussed in #79 issue.

I also renamed EndPoints -> Endpoints in XcodeServerEndPoints name in order to maintain the compatibility between names of files, classes and variables.

Please review.
