### PR TITLE
Bot Deletion Test

### DIFF
--- a/XcodeServerSDK.xcodeproj/project.pbxproj
+++ b/XcodeServerSDK.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		3AC47F411B586DFD008C4E42 /* get_integration.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AC47F3F1B586DFD008C4E42 /* get_integration.json */; };
 		3AC47F461B587C67008C4E42 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC47F451B587C67008C4E42 /* IntegrationTests.swift */; };
 		3AC47F471B587C67008C4E42 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC47F451B587C67008C4E42 /* IntegrationTests.swift */; };
+		3AE691081B62CA2300966937 /* bot_deletion.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AE691071B62CA2300966937 /* bot_deletion.json */; };
+		3AE691091B62CA2300966937 /* bot_deletion.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AE691071B62CA2300966937 /* bot_deletion.json */; };
 		3D19506C0E23052633263948 /* Pods_XcodeServerSDK___iOS_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBDD1F2C73FB1DFB681AD807 /* Pods_XcodeServerSDK___iOS_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		700C93561B54F58A00B3C6E6 /* get_devices.json in Resources */ = {isa = PBXBuildFile; fileRef = 700C93551B54F58A00B3C6E6 /* get_devices.json */; };
 		700C93571B54F58A00B3C6E6 /* get_devices.json in Resources */ = {isa = PBXBuildFile; fileRef = 700C93551B54F58A00B3C6E6 /* get_devices.json */; };
@@ -206,6 +208,7 @@
 		3ABE68651B3AC3C500FA0A61 /* DeviceSpecification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceSpecification.swift; sourceTree = "<group>"; };
 		3AC47F3F1B586DFD008C4E42 /* get_integration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_integration.json; sourceTree = "<group>"; };
 		3AC47F451B587C67008C4E42 /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		3AE691071B62CA2300966937 /* bot_deletion.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = bot_deletion.json; sourceTree = "<group>"; };
 		5092B32F595740C3EB6EE029 /* Pods-XcodeServerSDK - iOS Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XcodeServerSDK - iOS Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-XcodeServerSDK - iOS Tests/Pods-XcodeServerSDK - iOS Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		50E9132396FE4F9BF104B42C /* Pods_XcodeServerSDK___watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Pods_XcodeServerSDK___watchOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CA6A6E6E245E84BFBB93C35 /* Pods-XcodeServerSDK - iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XcodeServerSDK - iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-XcodeServerSDK - iOS/Pods-XcodeServerSDK - iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -396,6 +399,7 @@
 		3AD14B771B3F71C600BFDEAA /* Casettes */ = {
 			isa = PBXGroup;
 			children = (
+				3AE691071B62CA2300966937 /* bot_deletion.json */,
 				3AC47F3F1B586DFD008C4E42 /* get_integration.json */,
 				3A3853A11B4002C900B7F842 /* osx_bot.json */,
 				704B5FC31B455EE400989E4B /* get_repositories.json */,
@@ -438,11 +442,11 @@
 			isa = PBXGroup;
 			children = (
 				70C2D8371B431BCE008845FB /* XcodeServer+Auth.swift */,
-				70C2D8481B432A55008845FB /* XcodeServer+Repository.swift */,
-				70B43A851B43C95A004F9DEB /* XcodeServer+Device.swift */,
-				70B43A8C1B43D6EA004F9DEB /* XcodeServer+Platform.swift */,
-				70DE3FA61B443137000761B7 /* XcodeServer+Integration.swift */,
 				7027067D1B44548800E09FDF /* XcodeServer+Bot.swift */,
+				70B43A851B43C95A004F9DEB /* XcodeServer+Device.swift */,
+				70DE3FA61B443137000761B7 /* XcodeServer+Integration.swift */,
+				70B43A8C1B43D6EA004F9DEB /* XcodeServer+Platform.swift */,
+				70C2D8481B432A55008845FB /* XcodeServer+Repository.swift */,
 				702706841B445F6A00E09FDF /* XcodeServer+SCM.swift */,
 			);
 			path = "API Routes";
@@ -697,6 +701,7 @@
 				3AA922541B3F0E39005A0F73 /* scm_branches_response_error.json in Resources */,
 				3AA922501B3F0E39005A0F73 /* scm_branches_request_no_fingerprint.json in Resources */,
 				3AA922531B3F0E39005A0F73 /* scm_branches_response_success.json in Resources */,
+				3AE691091B62CA2300966937 /* bot_deletion.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -724,6 +729,7 @@
 				3AA9224F1B3F0E38005A0F73 /* scm_branches_response_error.json in Resources */,
 				3AA9224B1B3F0E38005A0F73 /* scm_branches_request_no_fingerprint.json in Resources */,
 				3AA9224E1B3F0E38005A0F73 /* scm_branches_response_success.json in Resources */,
+				3AE691081B62CA2300966937 /* bot_deletion.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XcodeServerSDK/XcodeServerEndpoints.swift
+++ b/XcodeServerSDK/XcodeServerEndpoints.swift
@@ -48,7 +48,10 @@ public class XcodeServerEndPoints {
             let bots = "\(base)/bots"
             if let bot = params?["bot"] {
                 let bot = "\(bots)/\(bot)"
-                if let rev = params?["rev"] {
+                if
+                    let rev = params?["rev"],
+                    let method = params?["method"] where method == "DELETE"
+                {
                     let rev = "\(bot)/\(rev)"
                     return rev
                 }

--- a/XcodeServerSDKTests/BotParsingTests.swift
+++ b/XcodeServerSDKTests/BotParsingTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import XcodeServerSDK
 import XCTest
+import XcodeServerSDK
 
 class BotParsingTests: XCTestCase {
     
@@ -36,6 +36,20 @@ class BotParsingTests: XCTestCase {
     }
     
     //MARK: bot
+    
+    func testDeleteBot() {
+        
+        let exp = self.expectationWithDescription("Network")
+        let server = self.getRecordingXcodeServer("bot_deletion")
+        
+        server.deleteBot("5f79bd4f6eb05c645336606cc790ccd7", revision: "5-4939a8253e8243107a0d4733490fd36e") { (success, error) in
+            XCTAssertNil(error)
+            XCTAssertTrue(success)
+            exp.fulfill()
+        }
+        self.waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
 //    func testBot() {
 //        
 //        let bot = self.botInFileWithName("bot_mac_xcode6")

--- a/XcodeServerSDKTests/Casettes/bot_deletion.json
+++ b/XcodeServerSDKTests/Casettes/bot_deletion.json
@@ -1,0 +1,29 @@
+{
+  "interactions" : [
+    {
+      "recorded_at" : 1437766154.706348,
+      "response" : {
+        "body" : "",
+        "body_format" : "base64_string",
+        "status" : 204,
+        "url" : "https:\/\/127.0.0.1:20343\/api\/bots\/5f79bd4f6eb05c645336606cc790ccd7\/5-4939a8253e8243107a0d4733490fd36e",
+        "headers" : {
+          "Etag" : "W\/\"a-b541a50d\"",
+          "X-XCSAPIVersion" : "3",
+          "X-XCSResponse-Status-Title" : "No Content",
+          "Keep-Alive" : "timeout=5; max=100",
+          "Connection" : "keep-alive",
+          "Date" : "Fri, 24 Jul 2015 19:29:13 GMT"
+        }
+      },
+      "request" : {
+        "method" : "DELETE",
+        "url" : "https:\/\/127.0.0.1:20343\/api\/bots\/5f79bd4f6eb05c645336606cc790ccd7\/5-4939a8253e8243107a0d4733490fd36e",
+        "headers" : {
+          "Authorization" : "Basic saGVzdGskbfluOfdsfmJJleWbGRz"
+        }
+      }
+    }
+  ],
+  "name" : "bot_deletion"
+}


### PR DESCRIPTION
- added a bot deletion test
- endpoint URL creation now uses `rev` only when method is `DELETE` (see discussion in #80)
