### PR TITLE
XcodeServerEndpoints.createRequest tests

### DIFF
--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -20,10 +20,44 @@ class XcodeServerEndpointsTests: XCTestCase {
         self.endpoints = XcodeServerEndpoints(serverConfig: serverConfig)
     }
     
+    // MARK: createRequest()
+    
     // If malformed URL is passed to request creation function it should early exit and retur nil
     func testMalformedURLCreation() {
         let expectation = endpoints?.createRequest(.GET, endpoint: .Bots, params: ["test": "test"], query: ["test//http\\": "!test"], body: ["test": "test"], doBasicAuth: true)
         XCTAssertNil(expectation, "Shouldn't create request from malformed URL")
+    }
+    
+    func testGETRequestCreation() {
+        let expectedUrl = NSURL(string: "https://127.0.0.1:20343/api/bots/bot_id/integrations?format=json")
+        let expectedRequest = NSMutableURLRequest(URL: expectedUrl!)
+        // HTTPMethod
+        expectedRequest.HTTPMethod = "GET"
+        // Authorization header: "test": "test"
+        expectedRequest.setValue("Basic dGVzdDp0ZXN0", forHTTPHeaderField: "Authorization")
+        
+        let request = self.endpoints?.createRequest(.GET, endpoint: .Integrations, params: ["bot": "bot_id"], query: ["format": "json"], body: nil, doBasicAuth: true)
+        XCTAssertEqual(expectedRequest, request!)
+    }
+    
+    func testPOSTRequestCreation() {
+        let expectedUrl = NSURL(string: "https://127.0.0.1:20343/api/auth/logout")
+        let expectedRequest = NSMutableURLRequest(URL: expectedUrl!)
+        // HTTPMethod
+        expectedRequest.HTTPMethod = "POST"
+        
+        let request = self.endpoints?.createRequest(.POST, endpoint: .Logout, params: nil, query: nil, body: nil, doBasicAuth: false)
+        XCTAssertEqual(expectedRequest, request!)
+    }
+    
+    func testDELETERequestCreation() {
+        let expectedUrl = NSURL(string: "https://127.0.0.1:20343/api/bots/bot_id/rev_id")
+        let expectedRequest = NSMutableURLRequest(URL: expectedUrl!)
+        // HTTPMethod
+        expectedRequest.HTTPMethod = "DELETE"
+        
+        let request = self.endpoints?.createRequest(.DELETE, endpoint: .Bots, params: ["bot": "bot_id", "rev": "rev_id", "method": "DELETE"], query: nil, body: nil, doBasicAuth: false)
+        XCTAssertEqual(expectedRequest, request!)
     }
     
     // MARK: endpointURL(.Bots)

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -28,6 +28,20 @@ class XcodeServerEndpointsTests: XCTestCase {
         XCTAssertNil(expectation, "Shouldn't create request from malformed URL")
     }
     
+    func testRequestCreationForEmptyAuthorizationParams() {
+        let expectedUrl = NSURL(string: "https://127.0.0.1:20343/api/bots/bot_id/integrations")
+        let expectedRequest = NSMutableURLRequest(URL: expectedUrl!)
+        // HTTPMethod
+        expectedRequest.HTTPMethod = "GET"
+        // Authorization header: "": ""
+        expectedRequest.setValue("Basic Og==", forHTTPHeaderField: "Authorization")
+        
+        let noAuthorizationConfig = try! XcodeServerConfig(host: "https://127.0.0.1")
+        let noAuthorizationEndpoints = XcodeServerEndpoints(serverConfig: noAuthorizationConfig)
+        let request = noAuthorizationEndpoints.createRequest(.GET, endpoint: .Integrations, params: ["bot": "bot_id"], query: nil, body: nil, doBasicAuth: true)
+        XCTAssertEqual(expectedRequest, request!)
+    }
+    
     func testGETRequestCreation() {
         let expectedUrl = NSURL(string: "https://127.0.0.1:20343/api/bots/bot_id/integrations?format=json")
         let expectedRequest = NSMutableURLRequest(URL: expectedUrl!)


### PR DESCRIPTION
Hey, I added three tests for `createRequest` method, but I don't have a clue how to 100% cover the `XcodeServerEndpoints` class.
Please take a look.

Btw. I have one proposition regarding `XcodeServer` class.
I would move the code below (from `sendRequestWithMethod` method) to `createRequest` method, because `createRequest` method can figure out `HTTP.Method` directly from its parameter. What do you think?

``` swift
var allParams = [
    "method": method.rawValue
]

//merge the two params
if let params = params {
    for (key, value) in params {
        allParams[key] = value
    }
}
```
