### PR TITLE
Refactoring of `sendRequestWithMethod`

### DIFF
--- a/XcodeServerSDK/XcodeServer.swift
+++ b/XcodeServerSDK/XcodeServer.swift
@@ -117,19 +117,7 @@ public extension XcodeServer {
     - parameter completion: Completion.
     */
     internal func sendRequestWithMethod(method: HTTP.Method, endpoint: XcodeServerEndpoints.Endpoint, params: [String: String]?, query: [String: String]?, body: NSDictionary?, completion: HTTP.Completion) {
-        
-        var allParams = [
-            "method": method.rawValue
-        ]
-        
-        //merge the two params
-        if let params = params {
-            for (key, value) in params {
-                allParams[key] = value
-            }
-        }
-        
-        if let request = self.endpoints.createRequest(method, endpoint: endpoint, params: allParams, query: query, body: body) {
+        if let request = self.endpoints.createRequest(method, endpoint: endpoint, params: params, query: query, body: body) {
             
             self.http.sendRequest(request, completion: { (response, body, error) -> () in
                 

--- a/XcodeServerSDK/XcodeServerEndpoints.swift
+++ b/XcodeServerSDK/XcodeServerEndpoints.swift
@@ -132,7 +132,18 @@ public class XcodeServerEndpoints {
     - returns: NSMutableRequest or nil if wrong URL was provided
     */
     func createRequest(method: HTTP.Method, endpoint: Endpoint, params: [String : String]? = nil, query: [String : String]? = nil, body: NSDictionary? = nil, doBasicAuth auth: Bool = true) -> NSMutableURLRequest? {
-        let endpointURL = self.endpointURL(endpoint, params: params)
+        var allParams = [
+            "method": method.rawValue
+        ]
+        
+        //merge the two params
+        if let params = params {
+            for (key, value) in params {
+                allParams[key] = value
+            }
+        }
+        
+        let endpointURL = self.endpointURL(endpoint, params: allParams)
         let queryString = HTTP.stringForQuery(query)
         let wholePath = "\(self.serverConfig.host):\(self.serverConfig.port)\(endpointURL)\(queryString)"
         

--- a/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
+++ b/XcodeServerSDKTests/XcodeServerEndpointsTests.swift
@@ -70,7 +70,7 @@ class XcodeServerEndpointsTests: XCTestCase {
         // HTTPMethod
         expectedRequest.HTTPMethod = "DELETE"
         
-        let request = self.endpoints?.createRequest(.DELETE, endpoint: .Bots, params: ["bot": "bot_id", "rev": "rev_id", "method": "DELETE"], query: nil, body: nil, doBasicAuth: false)
+        let request = self.endpoints?.createRequest(.DELETE, endpoint: .Bots, params: ["bot": "bot_id", "rev": "rev_id"], query: nil, body: nil, doBasicAuth: false)
         XCTAssertEqual(expectedRequest, request!)
     }
     


### PR DESCRIPTION
- Changes:
  Move the code responsible for adding `HTTP.Method` to params
  dictionary from `sendRequestWithMethod` method to `createRequest`
  method.
- Reason:
  In `createRequest` method it was possible to pass `HTTP.Method` using
  both `method` and `params` parameter. Passing `HTTP.Method` as a
  `method` parameter should be enough.
- Other changes:
  Update `testDELETERequestCreation` test
