### PR TITLE
Start using Nimble matchers in tests

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ end
 
 def tests
 	pod 'DVR', :git => "https://github.com/czechboy0/DVR.git", :tag => "v0.0.5-czechboy0"
+	pod 'Nimble', '2.0.0-rc.3'
 end
 
 target 'XcodeServerSDK' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,12 @@
 PODS:
   - BuildaUtils (0.1.0)
   - DVR (0.0.4-czechboy0)
+  - Nimble (2.0.0-rc.3)
 
 DEPENDENCIES:
   - BuildaUtils (= 0.1.0)
   - DVR (from `https://github.com/czechboy0/DVR.git`, tag `v0.0.5-czechboy0`)
+  - Nimble (= 2.0.0-rc.3)
 
 EXTERNAL SOURCES:
   DVR:
@@ -19,5 +21,6 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   BuildaUtils: cf7756290492ca286935d996c8bf4a3085662514
   DVR: 386f347071f55f3f9105239db6764483009ec875
+  Nimble: 9dff98ee195ffe7351d3b2fb01d3a1420fd97948
 
 COCOAPODS: 0.38.2

--- a/XcodeServerSDK.xcodeproj/xcshareddata/xcschemes/XcodeServerSDK.xcscheme
+++ b/XcodeServerSDK.xcodeproj/xcshareddata/xcschemes/XcodeServerSDK.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/XcodeServerSDKTests/LiveUpdatesTests.swift
+++ b/XcodeServerSDKTests/LiveUpdatesTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import Foundation
 @testable import XcodeServerSDK
+import Nimble
 
 class LiveUpdatesTests: XCTestCase {
     
@@ -16,47 +17,47 @@ class LiveUpdatesTests: XCTestCase {
         
         let message = "1::"
         let packets: [SocketIOPacket] = SocketIOHelper.parsePackets(message)
-        XCTAssertEqual(packets.count, 1)
+        expect(packets.count) == 1
         let packet = packets.first!
-        XCTAssertEqual(packet.type, SocketIOPacket.PacketType.Connect)
-        XCTAssertNil(packet.jsonPayload)
-        XCTAssertEqual(packet.stringPayload, "")
+        expect(packet.type) == SocketIOPacket.PacketType.Connect
+        expect(packet.jsonPayload).to(beNil())
+        expect(packet.stringPayload) == ""
     }
     
     func testParsing_ErrorPacket() {
         let message = "7:::1+0"
         let packets: [SocketIOPacket] = SocketIOHelper.parsePackets(message)
-        XCTAssertEqual(packets.count, 1)
+        expect(packets.count) == 1
         let packet = packets.first!
-        XCTAssertEqual(packet.type, SocketIOPacket.PacketType.Error)
+        expect(packet.type) == SocketIOPacket.PacketType.Error
         let (reason, advice) = packet.parseError()
-        XCTAssertEqual(reason, SocketIOPacket.ErrorReason.ClientNotHandshaken)
-        XCTAssertEqual(advice, SocketIOPacket.ErrorAdvice.Reconnect)
+        expect(reason) == SocketIOPacket.ErrorReason.ClientNotHandshaken
+        expect(advice) == SocketIOPacket.ErrorAdvice.Reconnect
     }
     
     func testParsing_SingleEventMessage() {
         
         let message = "5:::{\"name\":\"advisoryIntegrationStatus\",\"args\":[{\"message\":\"BuildaKit : Linking\",\"_id\":\"07a63fae4ff2d5a37eee830be556d143\",\"percentage\":0.7578125,\"botId\":\"07a63fae4ff2d5a37eee830be50c502a\"},null]}"
         let packets: [SocketIOPacket] = SocketIOHelper.parsePackets(message)
-        XCTAssertEqual(packets.count, 1)
+        expect(packets.count) == 1
         let packet = packets.first!
-        XCTAssertNotNil(packet.jsonPayload)
+        expect(packet.jsonPayload).toNot(beNil())
         let msg = LiveUpdateMessage(json: packet.jsonPayload!)
-        XCTAssertEqual(msg.type, LiveUpdateMessage.MessageType.AdvisoryIntegrationStatus)
-        XCTAssertEqual(msg.message, "BuildaKit : Linking")
-        XCTAssertEqual(msg.integrationId, "07a63fae4ff2d5a37eee830be556d143")
-        XCTAssertEqual(msg.progress, 0.7578125)
-        XCTAssertEqual(msg.botId, "07a63fae4ff2d5a37eee830be50c502a")
+        expect(msg.type) == LiveUpdateMessage.MessageType.AdvisoryIntegrationStatus
+        expect(msg.message) == "BuildaKit : Linking"
+        expect(msg.integrationId) == "07a63fae4ff2d5a37eee830be556d143"
+        expect(msg.progress) == 0.7578125
+        expect(msg.botId) == "07a63fae4ff2d5a37eee830be50c502a"
     }
     
     func testParsing_MultipleEventMessages() {
         let message = "�205�5:::{\"name\":\"advisoryIntegrationStatus\",\"args\":[{\"message\":\"Buildasaur : Linking\",\"_id\":\"07a63fae4ff2d5a37eee830be556d143\",\"percentage\":0.8392857360839844,\"botId\":\"07a63fae4ff2d5a37eee830be50c502a\"},null]}�218�5:::{\"name\":\"advisoryIntegrationStatus\",\"args\":[{\"message\":\"Buildasaur : Copying 1 of 3 files\",\"_id\":\"07a63fae4ff2d5a37eee830be556d143\",\"percentage\":0.8571428680419921,\"botId\":\"07a63fae4ff2d5a37eee830be50c502a\"},null]}�218�5:::{\"name\":\"advisoryIntegrationStatus\",\"args\":[{\"message\":\"Buildasaur : Copying 2 of 3 files\",\"_id\":\"07a63fae4ff2d5a37eee830be556d143\",\"percentage\":0.8607142639160156,\"botId\":\"07a63fae4ff2d5a37eee830be50c502a\"},null]}�228�5:::{\"name\":\"advisoryIntegrationStatus\",\"args\":[{\"message\":\"BuildaUtils : Compiling Swift source files\",\"_id\":\"07a63fae4ff2d5a37eee830be556d143\",\"percentage\":0.05511363506317139,\"botId\":\"07a63fae4ff2d5a37eee830be50c502a\"},null]}"
         let packets: [SocketIOPacket] = SocketIOHelper.parsePackets(message)
-        XCTAssertEqual(packets.count, 4)
+        expect(packets.count) == 4
         for packet in packets {
-            XCTAssertNotNil(packet.jsonPayload)
+            expect(packet.jsonPayload).toNot(beNil())
             let msg = LiveUpdateMessage(json: packet.jsonPayload!)
-            XCTAssertEqual(msg.type, LiveUpdateMessage.MessageType.AdvisoryIntegrationStatus)
+            expect(msg.type) == LiveUpdateMessage.MessageType.AdvisoryIntegrationStatus
         }
     }
 }


### PR DESCRIPTION
Introduced Nimble to the project, rewrote two test classes to use it as a proof-of-concept. works nicely.

Fixes #105.
