### PR TITLE
modelCode, modelName and modelUTI made optional in Device server entity

### DIFF
--- a/XcodeServerSDK/Server Entities/Device.swift
+++ b/XcodeServerSDK/Server Entities/Device.swift
@@ -15,7 +15,7 @@ public class Device : XcodeServerEntity {
     public let connected: Bool
     public let simulator: Bool
     public let modelCode: String? // Enum?
-    public let deviceType: String // Enum?
+    public let deviceType: String? // Enum?
     public let modelName: String?
     public let deviceECID: String?
     public let modelUTI: String?
@@ -37,11 +37,11 @@ public class Device : XcodeServerEntity {
         self.connected = try json.boolForKey("connected")
         self.osVersion = try json.stringForKey("osVersion")
         self.simulator = try json.boolForKey("simulator")
-        self.modelCode = try json.optionalStringForKey("modelCode")
-        self.deviceType = try json.stringForKey("deviceType")
-        self.modelName = try json.optionalStringForKey("modelName")
+        self.modelCode = json.optionalStringForKey("modelCode")
+        self.deviceType = json.optionalStringForKey("deviceType")
+        self.modelName = json.optionalStringForKey("modelName")
         self.deviceECID = json.optionalStringForKey("deviceECID")
-        self.modelUTI = try json.optionalStringForKey("modelUTI")
+        self.modelUTI = json.optionalStringForKey("modelUTI")
         if let proxyDevice = json.optionalDictionaryForKey("activeProxiedDevice") {
             self.activeProxiedDevice = try Device(json: proxyDevice)
         } else {

--- a/XcodeServerSDK/Server Entities/Device.swift
+++ b/XcodeServerSDK/Server Entities/Device.swift
@@ -14,11 +14,11 @@ public class Device : XcodeServerEntity {
     public let osVersion: String
     public let connected: Bool
     public let simulator: Bool
-    public let modelCode: String // Enum?
+    public let modelCode: String? // Enum?
     public let deviceType: String // Enum?
-    public let modelName: String
+    public let modelName: String?
     public let deviceECID: String?
-    public let modelUTI: String
+    public let modelUTI: String?
     public let activeProxiedDevice: Device?
     public let trusted: Bool
     public let name: String
@@ -37,11 +37,11 @@ public class Device : XcodeServerEntity {
         self.connected = try json.boolForKey("connected")
         self.osVersion = try json.stringForKey("osVersion")
         self.simulator = try json.boolForKey("simulator")
-        self.modelCode = try json.stringForKey("modelCode")
+        self.modelCode = try json.optionalStringForKey("modelCode")
         self.deviceType = try json.stringForKey("deviceType")
-        self.modelName = try json.stringForKey("modelName")
+        self.modelName = try json.optionalStringForKey("modelName")
         self.deviceECID = json.optionalStringForKey("deviceECID")
-        self.modelUTI = try json.stringForKey("modelUTI")
+        self.modelUTI = try json.optionalStringForKey("modelUTI")
         if let proxyDevice = json.optionalDictionaryForKey("activeProxiedDevice") {
             self.activeProxiedDevice = try Device(json: proxyDevice)
         } else {


### PR DESCRIPTION
This is a fix for https://github.com/czechboy0/Buildasaur/issues/283. As far as I understood, the Xcode Server instance had a few devices that were disconnected, but still in the list not having these properties, which was triggering JSON parsing issues.
