### PR TITLE
Added .tvOS to available device filters

### DIFF
--- a/XcodeServerSDK/Server Entities/DeviceSpecification.swift
+++ b/XcodeServerSDK/Server Entities/DeviceSpecification.swift
@@ -113,7 +113,7 @@ public class DeviceFilter : XcodeServerEntity {
         public static func availableFiltersForPlatform(platformType: DevicePlatform.PlatformType) -> [FilterType] {
             
             switch platformType {
-            case .iOS:
+            case .iOS, .tvOS:
                 return [
                     .AllAvailableDevicesAndSimulators,
                     .AllDevices,


### PR DESCRIPTION
![https___ioveracker-cbt_local___cbtnuggets___tvos](https://cloud.githubusercontent.com/assets/1653961/16704919/a3baa8d0-4532-11e6-8722-7e9650b211a2.png)

I think #137 needs to be merged before we can get this far--at least with my Xcode Server and the proxied watch mentioned on that PR.
