### PR TITLE
Workaround for missing key trigger condition key

### DIFF
--- a/XcodeServerSDK/Server Entities/TriggerConditions.swift
+++ b/XcodeServerSDK/Server Entities/TriggerConditions.swift
@@ -52,7 +52,7 @@ public class TriggerConditions : XcodeServerEntity {
         self.onAnalyzerWarnings = try json.boolForKey("onAnalyzerWarnings")
         self.onBuildErrors = try json.boolForKey("onBuildErrors")
         self.onFailingTests = try json.boolForKey("onFailingTests")
-        self.onInternalErrors = try json.boolForKey("onInternalErrors")
+        self.onInternalErrors = try? json.boolForKey("onInternalErrors") ?? false
         self.onSuccess = try json.boolForKey("onSuccess")
         self.onWarnings = try json.boolForKey("onWarnings")
         


### PR DESCRIPTION
`onInternalErrors` is missing in Xcode 8 Beta 6
